### PR TITLE
fix: Incorrect interception of non-BPF setsockopt calls #198

### DIFF
--- a/internal/profile/seccomp/seccomp.go
+++ b/internal/profile/seccomp/seccomp.go
@@ -121,26 +121,40 @@ func generateHardeningRules(rule string, syscalls map[string]specs.LinuxSyscall,
 			}
 		}
 	case "disallow-load-bpf-via-setsockopt":
-		// Note: We should append the arguments after initializing the LinuxSyscall
-		// object when we want to add new built-in rules for setsockopt().
-		if _, ok := syscalls["setsockopt"]; !ok {
-			syscalls["setsockopt"] = specs.LinuxSyscall{
-				Names:  []string{"setsockopt"},
-				Action: action,
-				Args: []specs.LinuxSeccompArg{
-					{
-						Index: 2,
-						Value: unix.SO_ATTACH_FILTER,
-						Op:    specs.OpEqualTo,
-					},
-					{
-						Index: 2,
-						Value: unix.SO_ATTACH_REUSEPORT_CBPF,
-						Op:    specs.OpEqualTo,
-					},
+		syscalls["setsockopt_so_attach_filter"] = specs.LinuxSyscall{
+			Names:  []string{"setsockopt"},
+			Action: action,
+			Args: []specs.LinuxSeccompArg{
+				{
+					Index: 1,
+					Value: unix.SOL_SOCKET,
+					Op:    specs.OpEqualTo,
 				},
-			}
+				{
+					Index: 2,
+					Value: unix.SO_ATTACH_FILTER,
+					Op:    specs.OpEqualTo,
+				},
+			},
 		}
+
+		syscalls["setsockopt_so_attach_reuseport_cbpf"] = specs.LinuxSyscall{
+			Names:  []string{"setsockopt"},
+			Action: action,
+			Args: []specs.LinuxSeccompArg{
+				{
+					Index: 1,
+					Value: unix.SOL_SOCKET,
+					Op:    specs.OpEqualTo,
+				},
+				{
+					Index: 2,
+					Value: unix.SO_ATTACH_REUSEPORT_CBPF,
+					Op:    specs.OpEqualTo,
+				},
+			},
+		}
+
 	case "disallow-userfaultfd-creation":
 		if _, ok := syscalls["userfaultfd"]; !ok {
 			syscalls["userfaultfd"] = specs.LinuxSyscall{


### PR DESCRIPTION
Fix incorrect interception of non-BPF setsockopt calls

The existing `disallow-load-bpf-via-setsockopt` rule intercepts `setsockopt` calls
based solely on `optname` (3rd argument) being `SO_ATTACH_FILTER` (26) or 
`SO_ATTACH_REUSEPORT_CBPF` (51), but does not validate the `level` (2nd argument).
This causes false positives when legitimate syscalls use the same `optname` values under 
different `level` contexts (e.g., `SOL_IPV6`).

Example of broken behavior:
setsockopt(fd, SOL_IPV6, IPV6_V6ONLY, [1], 4)  # 26=IPV6_V6ONLY (blocked incorrectly)

Fix:
- Add `level=SOL_SOCKET` check to Seccomp rules
- Restrict interception to only:
  - `level=SOL_SOCKET` (1) AND 
  - `optname=SO_ATTACH_FILTER` (26) 
    OR `optname=SO_ATTACH_REUSEPORT_CBPF` (51)

