### PR TITLE
feat: Add unspecified IP entity for all-zeros address matching

### DIFF
--- a/apis/varmor/v1beta1/varmorpolicy_types.go
+++ b/apis/varmor/v1beta1/varmorpolicy_types.go
@@ -112,12 +112,14 @@ const (
 	// PodSelfIP is an entity that represents the Pod's own IP addresses.
 	// Please note that pods may be allocated at most 1 address for each of IPv4 and IPv6.
 	PodSelfIP string = "pod-self"
+	// Unspecified is an entity that represents the all-zeros address — specifically, 0.0.0.0 and ::.
+	// Its full name is unspecified address, referring to binding to all interfaces.
+	Unspecified string = "unspecified"
 )
 
 type Destination struct {
-	// ip defines this rule on a particular IP. Please use a valid textual representation of an IP address or
-	// the `pod-self` entity to represent the Pod's own IP addresses. Note that the ip field and ipBlock
-	// field are mutually exclusive.
+	// ip defines this rule on a particular IP. Please use a valid textual representation of an IP, or special
+	// entities like "pod-self" or "unspecified". Note that the ip field and cidr field are mutually exclusive.
 	// +optional
 	IP string `json:"ip,omitempty"`
 	// cidr defines this rule on a particular CIDR. Note that the ip field and cidr field are mutually exclusive.

--- a/config/crds/crd.varmor.org_varmorclusterpolicies.yaml
+++ b/config/crds/crd.varmor.org_varmorclusterpolicies.yaml
@@ -230,10 +230,9 @@ spec:
                                         ip:
                                           description: ip defines this rule on a particular
                                             IP. Please use a valid textual representation
-                                            of an IP address or the `pod-self` entity
-                                            to represent the Pod's own IP addresses.
-                                            Note that the ip field and ipBlock field
-                                            are mutually exclusive.
+                                            of an IP, or special entities like "pod-self"
+                                            or "unspecified". Note that the ip field
+                                            and cidr field are mutually exclusive.
                                           type: string
                                         ports:
                                           description: ports define this rule on particular

--- a/config/crds/crd.varmor.org_varmorpolicies.yaml
+++ b/config/crds/crd.varmor.org_varmorpolicies.yaml
@@ -229,10 +229,9 @@ spec:
                                         ip:
                                           description: ip defines this rule on a particular
                                             IP. Please use a valid textual representation
-                                            of an IP address or the `pod-self` entity
-                                            to represent the Pod's own IP addresses.
-                                            Note that the ip field and ipBlock field
-                                            are mutually exclusive.
+                                            of an IP, or special entities like "pod-self"
+                                            or "unspecified". Note that the ip field
+                                            and cidr field are mutually exclusive.
                                           type: string
                                         ports:
                                           description: ports define this rule on particular

--- a/manifests/varmor/templates/crds/crd.varmor.org_varmorclusterpolicies.yaml
+++ b/manifests/varmor/templates/crds/crd.varmor.org_varmorclusterpolicies.yaml
@@ -230,10 +230,9 @@ spec:
                                         ip:
                                           description: ip defines this rule on a particular
                                             IP. Please use a valid textual representation
-                                            of an IP address or the `pod-self` entity
-                                            to represent the Pod's own IP addresses.
-                                            Note that the ip field and ipBlock field
-                                            are mutually exclusive.
+                                            of an IP, or special entities like "pod-self"
+                                            or "unspecified". Note that the ip field
+                                            and cidr field are mutually exclusive.
                                           type: string
                                         ports:
                                           description: ports define this rule on particular

--- a/manifests/varmor/templates/crds/crd.varmor.org_varmorpolicies.yaml
+++ b/manifests/varmor/templates/crds/crd.varmor.org_varmorpolicies.yaml
@@ -229,10 +229,9 @@ spec:
                                         ip:
                                           description: ip defines this rule on a particular
                                             IP. Please use a valid textual representation
-                                            of an IP address or the `pod-self` entity
-                                            to represent the Pod's own IP addresses.
-                                            Note that the ip field and ipBlock field
-                                            are mutually exclusive.
+                                            of an IP, or special entities like "pod-self"
+                                            or "unspecified". Note that the ip field
+                                            and cidr field are mutually exclusive.
                                           type: string
                                         ports:
                                           description: ports define this rule on particular

--- a/pkg/lsm/bpfenforcer/profile.go
+++ b/pkg/lsm/bpfenforcer/profile.go
@@ -191,7 +191,10 @@ func (enforcer *BpfEnforcer) applyNetworkRules(nsID uint32, networks []varmor.Ne
 					copy(rule.Ports[:], network.Address.Ports)
 				}
 
-				if network.Address.IP != varmor.PodSelfIP {
+				switch network.Address.IP {
+				case "", varmor.PodSelfIP, varmor.Unspecified:
+					break
+				default:
 					ip := net.ParseIP(network.Address.IP)
 					if ip.To4() != nil {
 						copy(rule.Address[:], ip.To4())

--- a/test/examples/2-bpf/vpol-bpf-enhance.yaml
+++ b/test/examples/2-bpf/vpol-bpf-enhance.yaml
@@ -59,6 +59,10 @@ spec:
               - port: 9980
               - port: 10250
                 endPort: 10255
+            - ip: pod-self
+              ports:
+              - port: 80
+                endPort: 8080
             toPods:
             - podSelector:
                 matchLabels:


### PR DESCRIPTION
This PR introduces support for the `unspecified` entity in network destination rules, enabling simplified access control for all-zeros addresses (0.0.0.0 and ::) used for binding to all interfaces.

Previously, users needed to create separate rules for both IPv4 (0.0.0.0) and IPv6 (::) unspecified addresses to achieve complete coverage. After introducing this feature, only one rule is needed to implement access control for unspecified addresses.

Changes:
* Added `Unspecified` constant with value "unspecified" to represent all-zeros addresses.
* Updated `Destination.IP` field documentation to include both "pod-self" and "unspecified" entities.
* Added enforcement logic to handle unspecified address matching for both IPv4 and IPv6.