### PR TITLE
feat: Add `localhost` entity for simplifying loopback address rules

### DIFF
--- a/apis/varmor/v1beta1/varmorpolicy_types.go
+++ b/apis/varmor/v1beta1/varmorpolicy_types.go
@@ -115,11 +115,13 @@ const (
 	// Unspecified is an entity that represents the all-zeros address — specifically, 0.0.0.0 and ::.
 	// Its full name is unspecified address, referring to binding to all interfaces.
 	Unspecified string = "unspecified"
+	// LocalhostIP is an entity that represents the loopback addresses - specifically, 127.0.0.1 and ::1.
+	LocalhostIP string = "localhost"
 )
 
 type Destination struct {
 	// ip defines this rule on a particular IP. Please use a valid textual representation of an IP, or special
-	// entities like "pod-self" or "unspecified". Note that the ip field and cidr field are mutually exclusive.
+	// entities like "pod-self", "unspecified" or "localhost". Note that the ip field and cidr field are mutually exclusive.
 	// +optional
 	IP string `json:"ip,omitempty"`
 	// cidr defines this rule on a particular CIDR. Note that the ip field and cidr field are mutually exclusive.

--- a/config/crds/crd.varmor.org_varmorclusterpolicies.yaml
+++ b/config/crds/crd.varmor.org_varmorclusterpolicies.yaml
@@ -230,9 +230,10 @@ spec:
                                         ip:
                                           description: ip defines this rule on a particular
                                             IP. Please use a valid textual representation
-                                            of an IP, or special entities like "pod-self"
-                                            or "unspecified". Note that the ip field
-                                            and cidr field are mutually exclusive.
+                                            of an IP, or special entities like "pod-self",
+                                            "unspecified" or "localhost". Note that
+                                            the ip field and cidr field are mutually
+                                            exclusive.
                                           type: string
                                         ports:
                                           description: ports define this rule on particular

--- a/config/crds/crd.varmor.org_varmorpolicies.yaml
+++ b/config/crds/crd.varmor.org_varmorpolicies.yaml
@@ -229,9 +229,10 @@ spec:
                                         ip:
                                           description: ip defines this rule on a particular
                                             IP. Please use a valid textual representation
-                                            of an IP, or special entities like "pod-self"
-                                            or "unspecified". Note that the ip field
-                                            and cidr field are mutually exclusive.
+                                            of an IP, or special entities like "pod-self",
+                                            "unspecified" or "localhost". Note that
+                                            the ip field and cidr field are mutually
+                                            exclusive.
                                           type: string
                                         ports:
                                           description: ports define this rule on particular

--- a/internal/agent/utils.go
+++ b/internal/agent/utils.go
@@ -24,8 +24,6 @@ import (
 
 	goversion "github.com/hashicorp/go-version"
 	"k8s.io/apimachinery/pkg/version"
-
-	varmorTypes "github.com/bytedance/vArmor/internal/types"
 )
 
 const (
@@ -140,17 +138,6 @@ func retrieveNodeName(inContainer bool) (string, error) {
 		return "", fmt.Errorf("the NODE_NAME environment variable doesn't exist")
 	}
 	return nodeName, nil
-}
-
-func newProfileStatus(namespace, name, nodeName string, status varmorTypes.Status, message string) *varmorTypes.ProfileStatus {
-	s := varmorTypes.ProfileStatus{
-		Namespace:   namespace,
-		ProfileName: name,
-		NodeName:    nodeName,
-		Status:      status,
-		Message:     message,
-	}
-	return &s
 }
 
 // This profile is not used to be loaded into the kernel.

--- a/internal/profile/bpf/custom.go
+++ b/internal/profile/bpf/custom.go
@@ -385,9 +385,20 @@ func GenerateRawNetworkEgressRuleWithIpCidrPorts(bpfContent *varmor.BpfContent, 
 
 func generateRawNetworkEgressRuleForDestinations(bpfContent *varmor.BpfContent, mode uint32, destinations []varmor.Destination) error {
 	for _, destination := range destinations {
-		err := GenerateRawNetworkEgressRuleWithIpCidrPorts(bpfContent, mode, destination.CIDR, destination.IP, destination.Ports)
-		if err != nil {
-			return err
+		if destination.IP == varmor.LocalhostIP {
+			err := GenerateRawNetworkEgressRuleWithIpCidrPorts(bpfContent, mode, destination.CIDR, "127.0.0.1", destination.Ports)
+			if err != nil {
+				return err
+			}
+			err = GenerateRawNetworkEgressRuleWithIpCidrPorts(bpfContent, mode, destination.CIDR, "::1", destination.Ports)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := GenerateRawNetworkEgressRuleWithIpCidrPorts(bpfContent, mode, destination.CIDR, destination.IP, destination.Ports)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/manifests/varmor/templates/crds/crd.varmor.org_varmorclusterpolicies.yaml
+++ b/manifests/varmor/templates/crds/crd.varmor.org_varmorclusterpolicies.yaml
@@ -230,9 +230,10 @@ spec:
                                         ip:
                                           description: ip defines this rule on a particular
                                             IP. Please use a valid textual representation
-                                            of an IP, or special entities like "pod-self"
-                                            or "unspecified". Note that the ip field
-                                            and cidr field are mutually exclusive.
+                                            of an IP, or special entities like "pod-self",
+                                            "unspecified" or "localhost". Note that
+                                            the ip field and cidr field are mutually
+                                            exclusive.
                                           type: string
                                         ports:
                                           description: ports define this rule on particular

--- a/manifests/varmor/templates/crds/crd.varmor.org_varmorpolicies.yaml
+++ b/manifests/varmor/templates/crds/crd.varmor.org_varmorpolicies.yaml
@@ -229,9 +229,10 @@ spec:
                                         ip:
                                           description: ip defines this rule on a particular
                                             IP. Please use a valid textual representation
-                                            of an IP, or special entities like "pod-self"
-                                            or "unspecified". Note that the ip field
-                                            and cidr field are mutually exclusive.
+                                            of an IP, or special entities like "pod-self",
+                                            "unspecified" or "localhost". Note that
+                                            the ip field and cidr field are mutually
+                                            exclusive.
                                           type: string
                                         ports:
                                           description: ports define this rule on particular

--- a/pkg/lsm/bpfenforcer/enforcer.go
+++ b/pkg/lsm/bpfenforcer/enforcer.go
@@ -361,8 +361,6 @@ func (enforcer *BpfEnforcer) eventHandler(stopCh <-chan struct{}) {
 					if err != nil {
 						logger.Error(err, "setPodIps() failed")
 					}
-				} else {
-					logger.Error(fmt.Errorf("unexpected behavior: unable to obtain the Pod IP of the container"), "setPodIps() failed")
 				}
 
 				// apply the BPF profile for the target container

--- a/pkg/runtime/monitor.go
+++ b/pkg/runtime/monitor.go
@@ -168,6 +168,12 @@ func (monitor *RuntimeMonitor) retrievePodInfo(containerInfo *varmortypes.Contai
 		}
 
 		if response.Status.Network != nil {
+			if response.Status.Linux != nil &&
+				response.Status.Linux.Namespaces != nil &&
+				response.Status.Linux.Namespaces.Options != nil &&
+				response.Status.Linux.Namespaces.Options.Network == runtimeapi.NamespaceMode_NODE {
+				return nil
+			}
 			containerInfo.PodIPs = append(containerInfo.PodIPs, response.Status.Network.Ip)
 			for _, ip := range response.Status.Network.AdditionalIps {
 				containerInfo.PodIPs = append(containerInfo.PodIPs, ip.Ip)


### PR DESCRIPTION
This PR introduces a new IP entity "localhost" to simplify network access control rules targeting loopback addresses (127.0.0.1 and ::1). Currently, users need to create two separate toDestination rules to restrict container access to both IPv4 and IPv6 loopback addresses. This enhancement consolidates that functionality into a single, more intuitive rule.