### PR TITLE
feat: Support Dynamic Removal of BPF Enforcer

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -497,6 +497,14 @@ func (agent *Agent) handleCreateOrUpdateArmorProfile(ap *varmor.ArmorProfile, ke
 			logger.Error(err, "SaveAndApplyBpfProfile()")
 			errorMessages = append(errorMessages, "SaveAndApplyBpfProfile(): "+err.Error())
 		}
+	} else if agent.bpfLsmSupported && agent.bpfEnforcer.IsBpfProfileExist(ap.Spec.Profile.Name) {
+		// Remove BPF profile if the policy no longer uses the BPF enforcer.
+		logger.Info(fmt.Sprintf("unloading the BPF profile '%s' from Node/%s's kernel", ap.Spec.Profile.Name, agent.nodeName))
+		err := agent.bpfEnforcer.DeleteBpfProfile(ap.Spec.Profile.Name)
+		if err != nil {
+			logger.Error(err, "DeleteBpfProfile()")
+			errorMessages = append(errorMessages, "DeleteBpfProfile(): "+err.Error())
+		}
 	}
 
 	// Seccomp

--- a/internal/policy/policy_controller.go
+++ b/internal/policy/policy_controller.go
@@ -374,15 +374,15 @@ func (c *PolicyController) ignoreUpdate(newVp *varmor.VarmorPolicy, oldAp *varmo
 		return true, err
 	}
 
-	// Disallow shutting down the enforcer that has been activated.
+	// Disallow shutting down the activated AppArmor or Seccomp enforcer.
 	newEnforcers := varmortypes.GetEnforcerType(newVp.Spec.Policy.Enforcer)
 	oldEnforcers := varmortypes.GetEnforcerType(oldAp.Spec.Profile.Enforcer)
-	if newEnforcers&oldEnforcers != oldEnforcers {
-		err := fmt.Errorf("disallow shutting down the enforcer that has been activated")
+	if (newEnforcers&oldEnforcers != oldEnforcers) && (newEnforcers|varmortypes.BPF != oldEnforcers) {
+		err := fmt.Errorf("disallow shutting down the activated AppArmor or Seccomp enforcer")
 		logger.Error(err, "update VarmorPolicy/status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"Modifying a policy to remove an already-set enforcer is not allowed. To remove enforcers, you must recreate the VarmorPolicy object.")
+			"Modifying a policy to remove the AppArmor or Seccomp enforcer is not allowed. To remove them, you need to recreate the VarmorPolicy object.")
 		return true, err
 	}
 

--- a/internal/policy/update.go
+++ b/internal/policy/update.go
@@ -44,10 +44,8 @@ func modifyDeploymentAnnotationsAndEnv(enforcer string, mode varmor.VarmorPolicy
 	// Clean up first
 	for key, value := range deploy.Spec.Template.Annotations {
 		// BPF
-		if (e & varmortypes.BPF) != 0 {
-			if strings.HasPrefix(key, "container.bpf.security.beta.varmor.org/") && value != "unconfined" {
-				delete(deploy.Spec.Template.Annotations, key)
-			}
+		if strings.HasPrefix(key, "container.bpf.security.beta.varmor.org/") && value != "unconfined" {
+			delete(deploy.Spec.Template.Annotations, key)
 		}
 		// AppArmor
 		if (e & varmortypes.AppArmor) != 0 {
@@ -181,10 +179,8 @@ func modifyStatefulSetAnnotationsAndEnv(enforcer string, mode varmor.VarmorPolic
 	// Clean up first
 	for key, value := range stateful.Spec.Template.Annotations {
 		// BPF
-		if (e & varmortypes.BPF) != 0 {
-			if strings.HasPrefix(key, "container.bpf.security.beta.varmor.org/") && value != "unconfined" {
-				delete(stateful.Spec.Template.Annotations, key)
-			}
+		if strings.HasPrefix(key, "container.bpf.security.beta.varmor.org/") && value != "unconfined" {
+			delete(stateful.Spec.Template.Annotations, key)
 		}
 		// AppArmor
 		if (e & varmortypes.AppArmor) != 0 {
@@ -318,10 +314,8 @@ func modifyDaemonSetAnnotationsAndEnv(enforcer string, mode varmor.VarmorPolicyM
 	// Clean up first
 	for key, value := range daemon.Spec.Template.Annotations {
 		// BPF
-		if (e & varmortypes.BPF) != 0 {
-			if strings.HasPrefix(key, "container.bpf.security.beta.varmor.org/") && value != "unconfined" {
-				delete(daemon.Spec.Template.Annotations, key)
-			}
+		if strings.HasPrefix(key, "container.bpf.security.beta.varmor.org/") && value != "unconfined" {
+			delete(daemon.Spec.Template.Annotations, key)
 		}
 		// AppArmor
 		if (e & varmortypes.AppArmor) != 0 {

--- a/test/examples/5-mutiple-enforcers/deploy-in-demo-ns.yaml
+++ b/test/examples/5-mutiple-enforcers/deploy-in-demo-ns.yaml
@@ -23,6 +23,7 @@ spec:
         # or VarmorClusterPolicy object.
         container.apparmor.security.beta.varmor.org/c0: unconfined
         container.seccomp.security.beta.varmor.org/c0: unconfined
+        container.bpf.security.beta.varmor.org/c0: unconfined
     spec:
       shareProcessNamespace: true
       containers:

--- a/test/examples/5-mutiple-enforcers/vpol-enhance.yaml
+++ b/test/examples/5-mutiple-enforcers/vpol-enhance.yaml
@@ -36,7 +36,8 @@ spec:
         network:
           egress:
             toDestinations:
-            - port: 443
+            - ports:
+              - port: 443
       # The custom Seccomp rules:
       syscallRawRules:
       # disallow chmod +x XXX, chmod 111 XXX, chmod 001 XXX, chmod 010 XXX...


### PR DESCRIPTION
# What this PR does
Enables users to dynamically remove the BPF enforcer from existing policies without recreating them.

# Key Features Added
- Modified policy controller to support removing BPF enforcers during policy updates.
- Updated policy cacher to prevent cache updates when non-BPF enforcers are removed.
- Modified armorprofile controller to support removing BPF profiles.
- Added logic to strip BPF annotations from workloads when the policy is deleted.

# Benefits
Improves flexibility for dynamic security policy management.

# Related Issue
#99 

