### PR TITLE
feat: Add Custom Metadata Injection to Audit Events

### DIFF
--- a/manifests/varmor/templates/daemonsets/agent.yaml
+++ b/manifests/varmor/templates/daemonsets/agent.yaml
@@ -48,6 +48,10 @@ spec:
               fieldPath: spec.nodeName
         - name: READINESS_PORT
           value: "{{ .Values.agent.network.readinessPort }}"
+        {{- if .Values.auditEventMetadata }}
+        - name: AUDIT_EVENT_METADATA
+          value: '{{- toJson .Values.auditEventMetadata}}'
+        {{- end }}
         {{- if or .Values.jsonLogFormat.enabled .Values.agent.args .Values.behaviorModeling.enabled .Values.bpfLsmEnforcer.enabled .Values.unloadAllAaProfiles.enabled .Values.removeAllSeccompProfiles.enabled }}
         args:
           {{- if .Values.jsonLogFormat.enabled }}

--- a/manifests/varmor/values.yaml
+++ b/manifests/varmor/values.yaml
@@ -43,6 +43,14 @@ jsonLogFormat:
   args:
   - --logFormat=json
 
+auditEventMetadata:
+  # The metadata is used to enrich the audit events.
+  # It can be used to add additional information to the audit events.
+  # For example, you can add the cluster id, name, region, or any other information that is relevant to your environment.
+  # clusterId: "ccvbve8igndqr18dnk0vg"
+  # clusterName: "production-cluster-1"
+  # clusterRegion: "cn-beijing"
+
 image:
   registry: ""
   namespace: varmor

--- a/pkg/auditor/audit.go
+++ b/pkg/auditor/audit.go
@@ -79,12 +79,13 @@ func (auditor *Auditor) processAuditEvent(event string) {
 
 		if deniedEvent {
 			auditor.violationLogger.Warn().
+				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
-				Str("containerID", info.ContainerID).
-				Str("containerName", info.ContainerName).
+				Str("podUID", info.PodUID).
 				Str("podName", info.PodName).
 				Str("podNamespace", info.PodNamespace).
-				Str("podUID", info.PodUID).
+				Str("containerID", info.ContainerID).
+				Str("containerName", info.ContainerName).
 				Uint32("pid", uint32(e.PID)).
 				Uint32("mntNsID", mntNsID).
 				Uint64("eventTimestamp", uint64(e.Epoch)).
@@ -98,12 +99,13 @@ func (auditor *Auditor) processAuditEvent(event string) {
 		// This can reduce the noise in the violation log.
 		if auditEvent || (allowedEvent && len(auditor.auditEventChs) == 0) {
 			auditor.violationLogger.Debug().
+				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
-				Str("containerID", info.ContainerID).
-				Str("containerName", info.ContainerName).
+				Str("podUID", info.PodUID).
 				Str("podName", info.PodName).
 				Str("podNamespace", info.PodNamespace).
-				Str("podUID", info.PodUID).
+				Str("containerID", info.ContainerID).
+				Str("containerName", info.ContainerName).
 				Uint32("pid", uint32(e.PID)).
 				Uint32("mntNsID", mntNsID).
 				Uint64("eventTimestamp", uint64(e.Epoch)).
@@ -167,12 +169,13 @@ func (auditor *Auditor) processAuditEvent(event string) {
 			}
 
 			auditor.violationLogger.Debug().
+				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
-				Str("containerID", info.ContainerID).
-				Str("containerName", info.ContainerName).
+				Str("podUID", info.PodUID).
 				Str("podName", info.PodName).
 				Str("podNamespace", info.PodNamespace).
-				Str("podUID", info.PodUID).
+				Str("containerID", info.ContainerID).
+				Str("containerName", info.ContainerName).
 				Uint32("pid", uint32(e.PID)).
 				Uint32("mntNsID", mntNsID).
 				Uint64("eventTimestamp", e.Epoch).

--- a/pkg/auditor/auditor.go
+++ b/pkg/auditor/auditor.go
@@ -35,6 +35,7 @@ import (
 const (
 	logDirectory    = "/var/log/varmor"
 	ratelimitSysctl = "/proc/sys/kernel/printk_ratelimit"
+	metadataJSONEnv = "AUDIT_EVENT_METADATA"
 )
 
 type Auditor struct {
@@ -58,6 +59,7 @@ type Auditor struct {
 	filePermissionMap      map[uint32]string
 	ptracePermissionMap    map[uint32]string
 	mountFlagMap           map[uint32]string
+	auditEventMetadata     map[string]string // auditEventMetadata used for storing additional information of the violation event
 	violationLogger        zerolog.Logger
 	log                    logr.Logger
 }
@@ -81,6 +83,7 @@ func NewAuditor(nodeName string, appArmorSupported, bpfLsmSupported, enableBehav
 		filePermissionMap:      initFilePermissionMap(),
 		ptracePermissionMap:    initPtracePermissionMap(),
 		mountFlagMap:           initMountFlagMap(),
+		auditEventMetadata:     loadAuditEventMetadata(),
 		log:                    log,
 	}
 
@@ -107,7 +110,7 @@ func NewAuditor(nodeName string, appArmorSupported, bpfLsmSupported, enableBehav
 			return nil, err
 		}
 		auditor.auditLogTail = t
-		auditor.log.Info("start tailing audit log", "path", auditor.auditLogPath)
+		auditor.log.Info("start tailing audit log", "path", auditor.auditLogPath, "metadata", auditor.auditEventMetadata)
 	}
 
 	// Load the ringbuf map of BPF enforcer

--- a/pkg/auditor/bpf.go
+++ b/pkg/auditor/bpf.go
@@ -285,12 +285,13 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 		case bpfenforcer.EnforceMode | bpfenforcer.AuditMode:
 			// Write the violation event that is denied by vArmor into the log file
 			auditor.violationLogger.Warn().
+				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
-				Str("containerID", auditor.containerCache[eventHeader.MntNs].ContainerID).
-				Str("containerName", auditor.containerCache[eventHeader.MntNs].ContainerName).
+				Str("podUID", auditor.containerCache[eventHeader.MntNs].PodUID).
 				Str("podName", auditor.containerCache[eventHeader.MntNs].PodName).
 				Str("podNamespace", auditor.containerCache[eventHeader.MntNs].PodNamespace).
-				Str("podUID", auditor.containerCache[eventHeader.MntNs].PodUID).
+				Str("containerID", auditor.containerCache[eventHeader.MntNs].ContainerID).
+				Str("containerName", auditor.containerCache[eventHeader.MntNs].ContainerName).
 				Uint32("pid", eventHeader.Tgid).
 				Uint32("mntNsID", eventHeader.MntNs).
 				Uint64("eventTimestamp", eventHeader.Ktime/uint64(time.Second)+auditor.bootTimestamp).
@@ -302,12 +303,13 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 		case bpfenforcer.AuditMode:
 			// Write the violation event into log the file
 			auditor.violationLogger.Debug().
+				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
-				Str("containerID", auditor.containerCache[eventHeader.MntNs].ContainerID).
-				Str("containerName", auditor.containerCache[eventHeader.MntNs].ContainerName).
+				Str("podUID", auditor.containerCache[eventHeader.MntNs].PodUID).
 				Str("podName", auditor.containerCache[eventHeader.MntNs].PodName).
 				Str("podNamespace", auditor.containerCache[eventHeader.MntNs].PodNamespace).
-				Str("podUID", auditor.containerCache[eventHeader.MntNs].PodUID).
+				Str("containerID", auditor.containerCache[eventHeader.MntNs].ContainerID).
+				Str("containerName", auditor.containerCache[eventHeader.MntNs].ContainerName).
 				Uint32("pid", eventHeader.Tgid).
 				Uint32("mntNsID", eventHeader.MntNs).
 				Uint64("eventTimestamp", eventHeader.Ktime/uint64(time.Second)+auditor.bootTimestamp).

--- a/pkg/auditor/utils.go
+++ b/pkg/auditor/utils.go
@@ -24,6 +24,7 @@ import "C"
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -176,6 +177,15 @@ func initMountFlagMap() map[uint32]string {
 		unix.MS_STRICTATIME:     "MS_STRICTATIME",
 		bpfenforcer.AaMayUmount: "UMOUNT",
 	}
+}
+
+func loadAuditEventMetadata() map[string]string {
+	metadata := make(map[string]string)
+	s := os.Getenv(metadataJSONEnv)
+	if s != "" {
+		json.Unmarshal([]byte(s), &metadata)
+	}
+	return metadata
 }
 
 func ParseAppArmorEvent(e string) (*AppArmorEvent, error) {


### PR DESCRIPTION
# What this PR does
It supports injecting custom metadata fields (e.g., cluster_id, region) into vArmor's audit events, enhancing observability.

# What type of PR is this?
/kind feature

# Main Code Changes
- Introduced `auditEventMetadata` configuration block in Helm values
- Added environment variable `AUDIT_EVENT_METADATA` for runtime configuration
- Enhanced agent to parse metadata and inject into audit event

# Benefits
- Reduces need for external log enrichment tools
- Improves incident response by adding contextual information