### PR TITLE
fix: Ensure manager detects BPF enforcer status for podServiceEgressControl

### DIFF
--- a/manifests/varmor/templates/deployments/manager.yaml
+++ b/manifests/varmor/templates/deployments/manager.yaml
@@ -35,10 +35,15 @@ spec:
         image: "{{ .Values.image.registry }}/{{ .Values.image.namespace }}/{{ .Values.manager.image.name }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
         command: ["/varmor/vArmor"]
-        {{- if or .Values.manager.args .Values.behaviorModeling.enabled .Values.podServiceEgressControl.enabled .Values.restartExistWorkloads.enabled .Values.bpfExclusiveMode.enabled .Values.metrics.enabled .Values.jsonLogFormat.enabled }}
+        {{- if or .Values.manager.args .Values.bpfLsmEnforcer.enabled .Values.behaviorModeling.enabled .Values.podServiceEgressControl.enabled .Values.restartExistWorkloads.enabled .Values.bpfExclusiveMode.enabled .Values.metrics.enabled .Values.jsonLogFormat.enabled }}
         args:
           {{- if .Values.manager.args }}
             {{- with .Values.manager.args }}
+              {{- toYaml . | nindent 8 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.bpfLsmEnforcer.enabled }}
+            {{- with .Values.manager.bpfLsmEnforcer.args }}
               {{- toYaml . | nindent 8 }}
             {{- end }}
           {{- end }}

--- a/manifests/varmor/values.yaml
+++ b/manifests/varmor/values.yaml
@@ -97,6 +97,10 @@ manager:
 
   args: []
 
+  bpfLsmEnforcer:
+    args:
+    - --enableBpfEnforcer
+
   behaviorModeling:
     args:
     - --enableBehaviorModeling


### PR DESCRIPTION
# What this PR does
Fixes a Helm template issue preventing manager from detecting BPF enforcer status, enabling proper validation of the podServiceEgressControl feature.

# What type of PR is this?
/kind bug

# Main Code Changes
- Updated manager deployment template to inject `--enableBpfEnforcer` flag
- Conditionally includes BPF enforcer arguments only when explicitly enabled
