### PR TITLE
feat: Improve `podServiceEgressControl` to target specific ports on service endpoints

### DIFF
--- a/internal/ipwatcher/transform.go
+++ b/internal/ipwatcher/transform.go
@@ -83,6 +83,7 @@ func TransformEndpointSliceFunc(obj interface{}) (interface{}, error) {
 				UID:             eps.UID,
 			},
 			Endpoints: eps.Endpoints,
+			Ports:     eps.Ports,
 		}, nil
 	}
 	return obj, nil


### PR DESCRIPTION
# What this PR does
Optimizes `podServiceEgressControl` to enforce traffic restrictions at the port level of the service's endpoint and dynamically update rules in response to EndpointSlice changes, improving policy precision and adaptability.

# What type of PR is this?
/kind feature

# Key Features Added
- Generates BPF rules that explicitly reference endpoint IPs and ports.
- Automatically updates egress rules when the ports of EndpointSlice are modified.

# Benefits
- Improves policy precision for the endpoints of services.