### PR TITLE
Enable `podServiceEgressControl` by default for Kubernetes >= v1.21

### DIFF
--- a/internal/ipwatcher/handlers.go
+++ b/internal/ipwatcher/handlers.go
@@ -1,0 +1,285 @@
+package ipwatcher
+
+import (
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
+)
+
+func (i *IPWatcher) updatePod(oldObj, newObj interface{}) {
+	logger := i.log.WithName("UpdateFunc()")
+	pod := newObj.(*corev1.Pod)
+	oldPod := oldObj.(*corev1.Pod)
+
+	if !reflect.DeepEqual(pod.Status.PodIPs, oldPod.Status.PodIPs) ||
+		!reflect.DeepEqual(pod.Labels, oldPod.Labels) {
+		logger.V(2).Info("pod updated", "new", pod, "old", oldPod)
+
+		IPs := []string{}
+		for _, ip := range pod.Status.PodIPs {
+			IPs = append(IPs, ip.IP)
+		}
+
+		i.queue.Add(&SlimObject{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Pod",
+			},
+			ObjectMeta: pod.ObjectMeta,
+			EventType:  "UPDATE",
+			IPs:        IPs,
+			AddedIPs:   IPs,
+		})
+	}
+}
+
+func (i *IPWatcher) deletePod(obj interface{}) {
+	logger := i.log.WithName("DeleteFunc()")
+	pod := obj.(*corev1.Pod)
+
+	if len(pod.Status.PodIPs) != 0 {
+		logger.V(2).Info("pod deleted", "pod", pod)
+
+		IPs := []string{}
+		for _, ip := range pod.Status.PodIPs {
+			IPs = append(IPs, ip.IP)
+		}
+
+		i.queue.Add(&SlimObject{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Pod",
+			},
+			ObjectMeta: pod.ObjectMeta,
+			EventType:  "DELETE",
+			IPs:        IPs,
+			DeletedIPs: IPs,
+		})
+	}
+}
+
+func (i *IPWatcher) addService(obj interface{}) {
+	logger := i.log.WithName("AddFunc()")
+	svc := obj.(*corev1.Service)
+
+	if len(svc.Spec.ClusterIPs) != 0 {
+		logger.V(2).Info("service added", "service", svc)
+
+		i.queue.Add(&SlimObject{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Service",
+			},
+			ObjectMeta: svc.ObjectMeta,
+			EventType:  "ADD",
+			IPs:        svc.Spec.ClusterIPs,
+			AddedIPs:   svc.Spec.ClusterIPs,
+		})
+	}
+}
+
+func (i *IPWatcher) updateService(oldObj, newObj interface{}) {
+	logger := i.log.WithName("UpdateFunc()")
+	svc := newObj.(*corev1.Service)
+	oldSvc := oldObj.(*corev1.Service)
+
+	addedIPs := svc.Spec.ClusterIPs
+
+	var deletedIPs []string
+	lastIPPort, ok := i.ipPortCache.Get(string(svc.UID))
+	if !ok {
+		lastIPPort.IPs = oldSvc.Spec.ClusterIPs
+	}
+	for _, lastIP := range lastIPPort.IPs {
+		found := false
+		for _, ip := range addedIPs {
+			if lastIP == ip {
+				found = true
+				break
+			}
+		}
+		if !found {
+			deletedIPs = append(deletedIPs, lastIP)
+		}
+	}
+
+	if len(deletedIPs) != 0 ||
+		!reflect.DeepEqual(addedIPs, lastIPPort.IPs) ||
+		!reflect.DeepEqual(svc.Labels, oldSvc.Labels) {
+		logger.V(2).Info("service updated", "new", svc, "old", oldSvc)
+
+		i.queue.Add(&SlimObject{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Service",
+			},
+			ObjectMeta: svc.ObjectMeta,
+			EventType:  "UPDATE",
+			IPs:        addedIPs,
+			AddedIPs:   addedIPs,
+			DeletedIPs: deletedIPs,
+		})
+	}
+}
+
+func (i *IPWatcher) deleteService(obj interface{}) {
+	logger := i.log.WithName("DeleteFunc()")
+	svc := obj.(*corev1.Service)
+
+	if len(svc.Spec.ClusterIPs) != 0 {
+		logger.V(2).Info("service deleted", "service", svc)
+
+		var deletedIPs []string
+		lastIPPort, ok := i.ipPortCache.Get(string(svc.UID))
+		if ok {
+			deletedIPs = lastIPPort.IPs
+		} else {
+			deletedIPs = svc.Spec.ClusterIPs
+		}
+
+		i.queue.Add(&SlimObject{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Service",
+			},
+			ObjectMeta: svc.ObjectMeta,
+			EventType:  "DELETE",
+			IPs:        deletedIPs,
+			DeletedIPs: deletedIPs,
+		})
+	}
+}
+
+func (i *IPWatcher) addEndpointSlice(obj interface{}) {
+	logger := i.log.WithName("AddFunc()")
+	eps := obj.(*discoveryv1.EndpointSlice)
+
+	if _, ok := eps.Labels["kubernetes.io/service-name"]; ok && len(eps.Endpoints) != 0 {
+		logger.V(2).Info("endpointslice added", "endpointslice", eps)
+
+		var addedIPs []string
+		for _, ep := range eps.Endpoints {
+			addedIPs = append(addedIPs, ep.Addresses...)
+		}
+
+		var ports []varmor.Port
+		for _, port := range eps.Ports {
+			if port.Port != nil {
+				ports = append(ports, varmor.Port{
+					Port: uint16(*port.Port),
+				})
+			}
+		}
+
+		i.queue.Add(&SlimObject{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "EndpointSlice",
+			},
+			ObjectMeta: eps.ObjectMeta,
+			EventType:  "ADD",
+			IPs:        addedIPs,
+			AddedIPs:   addedIPs,
+			Ports:      ports,
+		})
+	}
+}
+
+func (i *IPWatcher) updateEndpointSlice(oldObj, newObj interface{}) {
+	logger := i.log.WithName("UpdateFunc()")
+	eps := newObj.(*discoveryv1.EndpointSlice)
+	oldEps := oldObj.(*discoveryv1.EndpointSlice)
+
+	if _, ok := eps.Labels["kubernetes.io/service-name"]; !ok {
+		return
+	}
+
+	var addedIPs []string
+	for _, ep := range eps.Endpoints {
+		addedIPs = append(addedIPs, ep.Addresses...)
+	}
+
+	var ports []varmor.Port
+	for _, port := range eps.Ports {
+		if port.Port != nil {
+			ports = append(ports, varmor.Port{
+				Port: uint16(*port.Port),
+			})
+		}
+	}
+
+	var deletedIPs []string
+	lastIPPort, ok := i.ipPortCache.Get(string(eps.UID))
+	if !ok {
+		for _, ep := range oldEps.Endpoints {
+			lastIPPort.IPs = append(lastIPPort.IPs, ep.Addresses...)
+		}
+		for _, port := range oldEps.Ports {
+			if port.Port != nil {
+				lastIPPort.Ports = append(lastIPPort.Ports, varmor.Port{
+					Port: uint16(*port.Port),
+				})
+			}
+		}
+	}
+	isPortsNotChanged := reflect.DeepEqual(lastIPPort.Ports, ports)
+	for _, lastIP := range lastIPPort.IPs {
+		found := false
+		for _, ip := range addedIPs {
+			if lastIP == ip {
+				if isPortsNotChanged {
+					found = true
+				}
+				break
+			}
+		}
+		if !found {
+			deletedIPs = append(deletedIPs, lastIP)
+		}
+	}
+
+	if len(deletedIPs) != 0 ||
+		!reflect.DeepEqual(addedIPs, lastIPPort.IPs) ||
+		!reflect.DeepEqual(eps.Labels, oldEps.Labels) {
+		logger.V(2).Info("endpointslice updated", "new", eps, "old", oldEps, "lastIPPort", lastIPPort)
+
+		i.queue.Add(&SlimObject{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "EndpointSlice",
+			},
+			ObjectMeta: eps.ObjectMeta,
+			EventType:  "UPDATE",
+			IPs:        addedIPs,
+			AddedIPs:   addedIPs,
+			DeletedIPs: deletedIPs,
+			Ports:      ports,
+		})
+	}
+}
+
+func (i *IPWatcher) deleteEndpointSlice(obj interface{}) {
+	logger := i.log.WithName("DeleteFunc()")
+	eps := obj.(*discoveryv1.EndpointSlice)
+
+	if _, ok := eps.Labels["kubernetes.io/service-name"]; ok && len(eps.Endpoints) != 0 {
+		logger.V(2).Info("endpointslice deleted", "endpointslice", eps)
+
+		var deletedIPs []string
+		lastIPPort, ok := i.ipPortCache.Get(string(eps.UID))
+		if ok {
+			deletedIPs = lastIPPort.IPs
+		} else {
+			for _, ep := range eps.Endpoints {
+				deletedIPs = append(deletedIPs, ep.Addresses...)
+			}
+		}
+
+		i.queue.Add(&SlimObject{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "EndpointSlice",
+			},
+			ObjectMeta: eps.ObjectMeta,
+			EventType:  "DELETE",
+			IPs:        deletedIPs,
+			DeletedIPs: deletedIPs,
+		})
+	}
+}

--- a/internal/ipwatcher/ipwatcher.go
+++ b/internal/ipwatcher/ipwatcher.go
@@ -16,26 +16,21 @@ package ipwatcher
 
 import (
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	discoveryinformers "k8s.io/client-go/informers/discovery/v1"
-	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	discoverylisters "k8s.io/client-go/listers/discovery/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
 	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
-	statusmanager "github.com/bytedance/vArmor/internal/status/apis/v1"
 	varmortypes "github.com/bytedance/vArmor/internal/types"
 	varmorinterface "github.com/bytedance/vArmor/pkg/client/clientset/versioned/typed/varmor/v1beta1"
 )
@@ -57,15 +52,12 @@ type SlimObject struct {
 
 type IPWatcher struct {
 	varmorInterface  varmorinterface.CrdV1beta1Interface
-	podInterface     typedcore.PodInterface
 	podinformer      coreinformers.PodInformer
 	podLister        corelisters.PodLister
-	serviceInterface typedcore.ServiceInterface
 	serviceinformer  coreinformers.ServiceInformer
 	serviceLister    corelisters.ServiceLister
 	epsinformer      discoveryinformers.EndpointSliceInformer
 	epsLister        discoverylisters.EndpointSliceLister
-	statusManager    *statusmanager.StatusManager
 	queue            workqueue.RateLimitingInterface
 	ipPortCache      *IPPortCache
 	egressCache      map[string]varmortypes.EgressInfo
@@ -75,12 +67,9 @@ type IPWatcher struct {
 
 func NewIPWatcher(
 	varmorInterface varmorinterface.CrdV1beta1Interface,
-	podInterface typedcore.PodInterface,
-	serviceInterface typedcore.ServiceInterface,
 	podinformer coreinformers.PodInformer,
 	serviceinformer coreinformers.ServiceInformer,
 	epsinformer discoveryinformers.EndpointSliceInformer,
-	statusManager *statusmanager.StatusManager,
 	egressCache map[string]varmortypes.EgressInfo,
 	egressCacheMutex *sync.RWMutex,
 	log logr.Logger,
@@ -88,8 +77,6 @@ func NewIPWatcher(
 
 	i := IPWatcher{
 		varmorInterface:  varmorInterface,
-		podInterface:     podInterface,
-		serviceInterface: serviceInterface,
 		podinformer:      podinformer,
 		podLister:        podinformer.Lister(),
 		serviceinformer:  serviceinformer,
@@ -165,279 +152,21 @@ func (i *IPWatcher) Run(workers int, stopCh <-chan struct{}) {
 	// Register event handlers for Pod.
 	// We assume that the IPs of a Pod can be added but not changed during its lifecircle.
 	i.podinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			logger := i.log.WithName("UpdateFunc()")
-			pod := newObj.(*corev1.Pod)
-			oldPod := oldObj.(*corev1.Pod)
-
-			if !reflect.DeepEqual(pod.Status.PodIPs, oldPod.Status.PodIPs) ||
-				!reflect.DeepEqual(pod.Labels, oldPod.Labels) {
-				logger.V(2).Info("pod updated", "new", pod, "old", oldPod)
-
-				IPs := []string{}
-				for _, ip := range pod.Status.PodIPs {
-					IPs = append(IPs, ip.IP)
-				}
-
-				i.queue.Add(&SlimObject{
-					TypeMeta: metav1.TypeMeta{
-						Kind: "Pod",
-					},
-					ObjectMeta: pod.ObjectMeta,
-					EventType:  "UPDATE",
-					IPs:        IPs,
-					AddedIPs:   IPs,
-				})
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			logger := i.log.WithName("DeleteFunc()")
-			pod := obj.(*corev1.Pod)
-
-			if len(pod.Status.PodIPs) != 0 {
-				logger.V(2).Info("pod deleted", "pod", pod)
-
-				IPs := []string{}
-				for _, ip := range pod.Status.PodIPs {
-					IPs = append(IPs, ip.IP)
-				}
-
-				i.queue.Add(&SlimObject{
-					TypeMeta: metav1.TypeMeta{
-						Kind: "Pod",
-					},
-					ObjectMeta: pod.ObjectMeta,
-					EventType:  "DELETE",
-					IPs:        IPs,
-					DeletedIPs: IPs,
-				})
-			}
-		},
+		UpdateFunc: i.updatePod,
+		DeleteFunc: i.deletePod,
 	})
 
 	// Register event handlers for Service.
 	i.serviceinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			logger := i.log.WithName("AddFunc()")
-			svc := obj.(*corev1.Service)
-
-			if len(svc.Spec.ClusterIPs) != 0 {
-				logger.V(2).Info("service added", "service", svc)
-
-				i.queue.Add(&SlimObject{
-					TypeMeta: metav1.TypeMeta{
-						Kind: "Service",
-					},
-					ObjectMeta: svc.ObjectMeta,
-					EventType:  "ADD",
-					IPs:        svc.Spec.ClusterIPs,
-					AddedIPs:   svc.Spec.ClusterIPs,
-				})
-			}
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			logger := i.log.WithName("UpdateFunc()")
-			svc := newObj.(*corev1.Service)
-			oldSvc := oldObj.(*corev1.Service)
-
-			addedIPs := svc.Spec.ClusterIPs
-
-			var deletedIPs []string
-			lastIPPort, ok := i.ipPortCache.Get(string(svc.UID))
-			if !ok {
-				lastIPPort.IPs = oldSvc.Spec.ClusterIPs
-			}
-			for _, lastIP := range lastIPPort.IPs {
-				found := false
-				for _, ip := range addedIPs {
-					if lastIP == ip {
-						found = true
-						break
-					}
-				}
-				if !found {
-					deletedIPs = append(deletedIPs, lastIP)
-				}
-			}
-
-			if len(deletedIPs) != 0 ||
-				!reflect.DeepEqual(addedIPs, lastIPPort.IPs) ||
-				!reflect.DeepEqual(svc.Labels, oldSvc.Labels) {
-				logger.V(2).Info("service updated", "new", svc, "old", oldSvc)
-
-				i.queue.Add(&SlimObject{
-					TypeMeta: metav1.TypeMeta{
-						Kind: "Service",
-					},
-					ObjectMeta: svc.ObjectMeta,
-					EventType:  "UPDATE",
-					IPs:        addedIPs,
-					AddedIPs:   addedIPs,
-					DeletedIPs: deletedIPs,
-				})
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			logger := i.log.WithName("DeleteFunc()")
-			svc := obj.(*corev1.Service)
-
-			if len(svc.Spec.ClusterIPs) != 0 {
-				logger.V(2).Info("service deleted", "service", svc)
-
-				var deletedIPs []string
-				lastIPPort, ok := i.ipPortCache.Get(string(svc.UID))
-				if ok {
-					deletedIPs = lastIPPort.IPs
-				} else {
-					deletedIPs = svc.Spec.ClusterIPs
-				}
-
-				i.queue.Add(&SlimObject{
-					TypeMeta: metav1.TypeMeta{
-						Kind: "Service",
-					},
-					ObjectMeta: svc.ObjectMeta,
-					EventType:  "DELETE",
-					IPs:        deletedIPs,
-					DeletedIPs: deletedIPs,
-				})
-			}
-		}})
+		AddFunc:    i.addService,
+		UpdateFunc: i.updateService,
+		DeleteFunc: i.deleteService})
 
 	// Register event handlers for EndpointSlice.
 	i.epsinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			logger := i.log.WithName("AddFunc()")
-			eps := obj.(*discoveryv1.EndpointSlice)
-
-			if _, ok := eps.Labels["kubernetes.io/service-name"]; ok && len(eps.Endpoints) != 0 {
-				logger.V(2).Info("endpointslice added", "endpointslice", eps)
-
-				var addedIPs []string
-				for _, ep := range eps.Endpoints {
-					addedIPs = append(addedIPs, ep.Addresses...)
-				}
-
-				var ports []varmor.Port
-				for _, port := range eps.Ports {
-					if port.Port != nil {
-						ports = append(ports, varmor.Port{
-							Port: uint16(*port.Port),
-						})
-					}
-				}
-
-				i.queue.Add(&SlimObject{
-					TypeMeta: metav1.TypeMeta{
-						Kind: "EndpointSlice",
-					},
-					ObjectMeta: eps.ObjectMeta,
-					EventType:  "ADD",
-					IPs:        addedIPs,
-					AddedIPs:   addedIPs,
-					Ports:      ports,
-				})
-			}
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			logger := i.log.WithName("UpdateFunc()")
-			eps := newObj.(*discoveryv1.EndpointSlice)
-			oldEps := oldObj.(*discoveryv1.EndpointSlice)
-
-			if _, ok := eps.Labels["kubernetes.io/service-name"]; !ok {
-				return
-			}
-
-			var addedIPs []string
-			for _, ep := range eps.Endpoints {
-				addedIPs = append(addedIPs, ep.Addresses...)
-			}
-
-			var ports []varmor.Port
-			for _, port := range eps.Ports {
-				if port.Port != nil {
-					ports = append(ports, varmor.Port{
-						Port: uint16(*port.Port),
-					})
-				}
-			}
-
-			var deletedIPs []string
-			lastIPPort, ok := i.ipPortCache.Get(string(eps.UID))
-			if !ok {
-				for _, ep := range oldEps.Endpoints {
-					lastIPPort.IPs = append(lastIPPort.IPs, ep.Addresses...)
-				}
-				for _, port := range oldEps.Ports {
-					if port.Port != nil {
-						lastIPPort.Ports = append(lastIPPort.Ports, varmor.Port{
-							Port: uint16(*port.Port),
-						})
-					}
-				}
-			}
-			isPortsNotChanged := reflect.DeepEqual(lastIPPort.Ports, ports)
-			for _, lastIP := range lastIPPort.IPs {
-				found := false
-				for _, ip := range addedIPs {
-					if lastIP == ip {
-						if isPortsNotChanged {
-							found = true
-						}
-						break
-					}
-				}
-				if !found {
-					deletedIPs = append(deletedIPs, lastIP)
-				}
-			}
-
-			if len(deletedIPs) != 0 ||
-				!reflect.DeepEqual(addedIPs, lastIPPort.IPs) ||
-				!reflect.DeepEqual(eps.Labels, oldEps.Labels) {
-				logger.V(2).Info("endpointslice updated", "new", eps, "old", oldEps, "lastIPPort", lastIPPort)
-
-				i.queue.Add(&SlimObject{
-					TypeMeta: metav1.TypeMeta{
-						Kind: "EndpointSlice",
-					},
-					ObjectMeta: eps.ObjectMeta,
-					EventType:  "UPDATE",
-					IPs:        addedIPs,
-					AddedIPs:   addedIPs,
-					DeletedIPs: deletedIPs,
-					Ports:      ports,
-				})
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			logger := i.log.WithName("DeleteFunc()")
-			eps := obj.(*discoveryv1.EndpointSlice)
-
-			if _, ok := eps.Labels["kubernetes.io/service-name"]; ok && len(eps.Endpoints) != 0 {
-				logger.V(2).Info("endpointslice deleted", "endpointslice", eps)
-
-				var deletedIPs []string
-				lastIPPort, ok := i.ipPortCache.Get(string(eps.UID))
-				if ok {
-					deletedIPs = lastIPPort.IPs
-				} else {
-					for _, ep := range eps.Endpoints {
-						deletedIPs = append(deletedIPs, ep.Addresses...)
-					}
-				}
-
-				i.queue.Add(&SlimObject{
-					TypeMeta: metav1.TypeMeta{
-						Kind: "EndpointSlice",
-					},
-					ObjectMeta: eps.ObjectMeta,
-					EventType:  "DELETE",
-					IPs:        deletedIPs,
-					DeletedIPs: deletedIPs,
-				})
-			}
-		}})
+		AddFunc:    i.addEndpointSlice,
+		UpdateFunc: i.updateEndpointSlice,
+		DeleteFunc: i.deleteEndpointSlice})
 
 	for index := 0; index < workers; index++ {
 		go wait.Until(i.worker, time.Second, stopCh)

--- a/internal/ipwatcher/transform.go
+++ b/internal/ipwatcher/transform.go
@@ -23,17 +23,17 @@ import (
 func Transform(obj interface{}) (interface{}, error) {
 	switch v := obj.(type) {
 	case *corev1.Pod:
-		return TransformPodFunc(v)
+		return transformPodFunc(v)
 	case *corev1.Service:
-		return TransformServiceFunc(v)
+		return transformServiceFunc(v)
 	case *discoveryv1.EndpointSlice:
-		return TransformEndpointSliceFunc(v)
+		return transformEndpointSliceFunc(v)
 	default:
 		return obj, nil
 	}
 }
 
-func TransformPodFunc(obj interface{}) (interface{}, error) {
+func transformPodFunc(obj interface{}) (interface{}, error) {
 	if pod, ok := obj.(*corev1.Pod); ok {
 		return &corev1.Pod{
 			TypeMeta: pod.TypeMeta,
@@ -52,7 +52,7 @@ func TransformPodFunc(obj interface{}) (interface{}, error) {
 	return obj, nil
 }
 
-func TransformServiceFunc(obj interface{}) (interface{}, error) {
+func transformServiceFunc(obj interface{}) (interface{}, error) {
 	if svc, ok := obj.(*corev1.Service); ok {
 		return &corev1.Service{
 			TypeMeta: svc.TypeMeta,
@@ -71,7 +71,7 @@ func TransformServiceFunc(obj interface{}) (interface{}, error) {
 	return obj, nil
 }
 
-func TransformEndpointSliceFunc(obj interface{}) (interface{}, error) {
+func transformEndpointSliceFunc(obj interface{}) (interface{}, error) {
 	if eps, ok := obj.(*discoveryv1.EndpointSlice); ok {
 		return &discoveryv1.EndpointSlice{
 			TypeMeta: eps.TypeMeta,

--- a/internal/profile/bpf/custom.go
+++ b/internal/profile/bpf/custom.go
@@ -565,8 +565,12 @@ func generateRawNetworkEgressRule(
 		return nil, fmt.Errorf("failed to generate network egress rule for bolocking access destinations. error: %w", err)
 	}
 
-	if !enablePodServiceEgressControl {
+	if len(rule.ToPods) == 0 && len(rule.ToServices) == 0 {
 		return nil, nil
+	}
+
+	if (len(rule.ToPods) != 0 || len(rule.ToServices) != 0) && !enablePodServiceEgressControl {
+		return nil, fmt.Errorf("the PodServiceEgressControl feature is required to generate network egress rule for Pods and Services")
 	}
 
 	egressInfo := varmortypes.EgressInfo{}

--- a/manifests/varmor/templates/deployments/manager.yaml
+++ b/manifests/varmor/templates/deployments/manager.yaml
@@ -52,9 +52,11 @@ spec:
               {{- toYaml . | nindent 8 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.podServiceEgressControl.enabled }}
-            {{- with .Values.manager.podServiceEgressControl.args }}
-              {{- toYaml . | nindent 8 }}
+          {{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version }}
+            {{- if .Values.podServiceEgressControl.enabled }}
+              {{- with .Values.manager.podServiceEgressControl.args }}
+                {{- toYaml . | nindent 8 }}
+              {{- end }}
             {{- end }}
           {{- end }}
           {{- if .Values.restartExistWorkloads.enabled }}

--- a/manifests/varmor/values.yaml
+++ b/manifests/varmor/values.yaml
@@ -30,7 +30,7 @@ behaviorModeling:
   enabled: false
 
 podServiceEgressControl:
-  enabled: false
+  enabled: true
 
 unloadAllAaProfiles:
   enabled: false


### PR DESCRIPTION
# What this PR does
Enables the `podServiceEgressControl` feature by default for Kubernetes clusters running version v1.21 or higher.

# What type of PR is this?
/kind feature

# Main Code Changes
- Added explicit check to prevent generating rules for Pods/Services when the feature is disabled.  
- Set `podServiceEgressControl.enabled: true` in values.yaml.
- Updated Helm template to enable the feature when Kubernetes is v1.21 or higher.

# Benefits
Simplifies deployment by reducing the need for manual feature enablement  