### PR TITLE
feat: Add new built-in rules

### DIFF
--- a/internal/policy/clusterpolicy_controller.go
+++ b/internal/policy/clusterpolicy_controller.go
@@ -312,7 +312,7 @@ func (c *ClusterPolicyController) handleAddVarmorClusterPolicy(vcp *varmor.Varmo
 	}
 
 	// Cache the egress information for the policy which has network egress rules with toPods and toService fields
-	if egressInfo != nil {
+	if egressInfo != nil && (len(egressInfo.ToPods) > 0 || len(egressInfo.ToServices) > 0) {
 		policyKey := vcp.Name
 		c.egressCacheMutex.Lock()
 		c.egressCache[policyKey] = *egressInfo
@@ -478,7 +478,10 @@ func (c *ClusterPolicyController) handleUpdateVarmorClusterPolicy(newVcp *varmor
 	if egressInfo != nil {
 		policyKey := newVcp.Name
 		c.egressCacheMutex.Lock()
-		c.egressCache[policyKey] = *egressInfo
+		delete(c.egressCache, policyKey)
+		if len(egressInfo.ToPods) > 0 || len(egressInfo.ToServices) > 0 {
+			c.egressCache[policyKey] = *egressInfo
+		}
 		c.egressCacheMutex.Unlock()
 		logger.Info("egress cache updated", "policy key", policyKey, "egress info", egressInfo)
 	}

--- a/internal/policy/policy_controller.go
+++ b/internal/policy/policy_controller.go
@@ -316,7 +316,7 @@ func (c *PolicyController) handleAddVarmorPolicy(vp *varmor.VarmorPolicy) error 
 	}
 
 	// Cache the egress information for the policy which has network egress rules with toPods and toService fields
-	if egressInfo != nil {
+	if egressInfo != nil && (len(egressInfo.ToPods) > 0 || len(egressInfo.ToServices) > 0) {
 		policyKey := vp.Namespace + "/" + vp.Name
 		c.egressCacheMutex.Lock()
 		c.egressCache[policyKey] = *egressInfo
@@ -482,7 +482,10 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 	if egressInfo != nil {
 		policyKey := newVp.Namespace + "/" + newVp.Name
 		c.egressCacheMutex.Lock()
-		c.egressCache[policyKey] = *egressInfo
+		delete(c.egressCache, policyKey)
+		if len(egressInfo.ToPods) > 0 || len(egressInfo.ToServices) > 0 {
+			c.egressCache[policyKey] = *egressInfo
+		}
 		c.egressCacheMutex.Unlock()
 		logger.Info("egress cache updated", "policy key", policyKey, "egress info", egressInfo)
 	}

--- a/internal/profile/bpf/bpf.go
+++ b/internal/profile/bpf/bpf.go
@@ -392,7 +392,14 @@ func generateVulMitigationRules(content *varmor.BpfContent, mode uint32, rule st
 	return nil
 }
 
-func generateAttackProtectionRules(content *varmor.BpfContent, mode uint32, rule string) error {
+func generateAttackProtectionRules(
+	kubeClient *kubernetes.Clientset,
+	content *varmor.BpfContent,
+	mode uint32,
+	rule string,
+	enablePodServiceEgressControl bool,
+	egressInfo *varmortypes.EgressInfo) error {
+
 	var fileContent *varmor.FileContent
 	var networkContent *varmor.NetworkContent
 	var err error
@@ -444,7 +451,7 @@ func generateAttackProtectionRules(content *varmor.BpfContent, mode uint32, rule
 			return err
 		}
 		content.Files = append(content.Files, *fileContent)
-	case "disallow-metadata-service":
+	case "block-access-to-metadata-service", "disallow-metadata-service":
 		// For Aliyun, Volc Engine, etc.
 		networkContent, err = newBpfNetworkConnectRule(mode, "", "100.96.0.96", 0, 0, nil)
 		if err != nil {
@@ -583,6 +590,19 @@ func generateAttackProtectionRules(content *varmor.BpfContent, mode uint32, rule
 			return err
 		}
 		content.Networks = append(content.Networks, *networkContent)
+	case "block-access-to-kube-apiserver":
+		if enablePodServiceEgressControl {
+			service, err := generateRawNetworkEgressRuleForServices(kubeClient, content, mode, varmor.Service{
+				Namespace: "default",
+				Name:      "kubernetes",
+			})
+			if err != nil {
+				return fmt.Errorf("failed to generate network egress rule for blocking access to the kube-apiserver. error: %w", err)
+			}
+			if service != nil {
+				egressInfo.ToServices = append(egressInfo.ToServices, *service)
+			}
+		}
 	}
 	return nil
 }
@@ -591,8 +611,10 @@ func GenerateEnhanceProtectProfile(
 	kubeClient *kubernetes.Clientset,
 	enhanceProtect *varmor.EnhanceProtect,
 	bpfContent *varmor.BpfContent,
-	enablePodServiceEgressControl bool) (egressInfo *varmortypes.EgressInfo, err error) {
+	enablePodServiceEgressControl bool,
+	egressInfo *varmortypes.EgressInfo) error {
 
+	var err error
 	var mode uint32
 
 	if enhanceProtect.AuditViolations {
@@ -607,7 +629,7 @@ func GenerateEnhanceProtectProfile(
 	if !enhanceProtect.Privileged {
 		err = GenerateRuntimeDefaultProfile(bpfContent, mode)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
@@ -615,7 +637,7 @@ func GenerateEnhanceProtectProfile(
 	for _, rule := range enhanceProtect.HardeningRules {
 		err = generateHardeningRules(bpfContent, mode, enhanceProtect.Privileged, rule)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
@@ -623,7 +645,7 @@ func GenerateEnhanceProtectProfile(
 	for _, rule := range enhanceProtect.VulMitigationRules {
 		err = generateVulMitigationRules(bpfContent, mode, rule)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
@@ -631,9 +653,9 @@ func GenerateEnhanceProtectProfile(
 	for _, attackProtectionRule := range enhanceProtect.AttackProtectionRules {
 		if len(attackProtectionRule.Targets) == 0 {
 			for _, rule := range attackProtectionRule.Rules {
-				err = generateAttackProtectionRules(bpfContent, mode, rule)
+				err = generateAttackProtectionRules(kubeClient, bpfContent, mode, rule, enablePodServiceEgressControl, egressInfo)
 				if err != nil {
-					return nil, err
+					return err
 				}
 			}
 		}
@@ -641,31 +663,31 @@ func GenerateEnhanceProtectProfile(
 
 	// Custom
 	if enhanceProtect.BpfRawRules != nil {
-		egressInfo, err = generateCustomRules(kubeClient, enhanceProtect, bpfContent, mode, enablePodServiceEgressControl)
+		err = generateCustomRules(kubeClient, enhanceProtect, bpfContent, mode, enablePodServiceEgressControl, egressInfo)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	if len(bpfContent.Files) > bpfenforcer.MaxBpfFileRuleCount {
-		return nil, fmt.Errorf("the maximum number of BPF file rules exceeded (max: %d, expected: %d)",
+		return fmt.Errorf("the maximum number of BPF file rules exceeded (max: %d, expected: %d)",
 			bpfenforcer.MaxBpfFileRuleCount, len(bpfContent.Files))
 	}
 
 	if len(bpfContent.Processes) > bpfenforcer.MaxBpfBprmRuleCount {
-		return nil, fmt.Errorf("the maximum number of BPF bprm rules exceeded (max: %d, expected: %d)",
+		return fmt.Errorf("the maximum number of BPF bprm rules exceeded (max: %d, expected: %d)",
 			bpfenforcer.MaxBpfBprmRuleCount, len(bpfContent.Processes))
 	}
 
 	if len(bpfContent.Networks) > bpfenforcer.MaxBpfNetworkRuleCount {
-		return nil, fmt.Errorf("the maximum number of BPF network rules exceeded (max: %d, expected: %d)",
+		return fmt.Errorf("the maximum number of BPF network rules exceeded (max: %d, expected: %d)",
 			bpfenforcer.MaxBpfNetworkRuleCount, len(bpfContent.Networks))
 	}
 
 	if len(bpfContent.Mounts) > bpfenforcer.MaxBpfMountRuleCount {
-		return nil, fmt.Errorf("the maximum number of BPF mount rules exceeded (max: %d, expected: %d)",
+		return fmt.Errorf("the maximum number of BPF mount rules exceeded (max: %d, expected: %d)",
 			bpfenforcer.MaxBpfMountRuleCount, len(bpfContent.Mounts))
 	}
 
-	return egressInfo, nil
+	return nil
 }

--- a/internal/profile/bpf/bpf_test.go
+++ b/internal/profile/bpf/bpf_test.go
@@ -20,6 +20,7 @@ import (
 	"gotest.tools/assert"
 
 	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
+	varmortypes "github.com/bytedance/vArmor/internal/types"
 	"github.com/bytedance/vArmor/pkg/lsm/bpfenforcer"
 )
 
@@ -33,7 +34,7 @@ func TestGenerateRawNetworkEgressRule_1(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, uint32(bpfenforcer.Ipv6Match|bpfenforcer.PreciseMatch), bpfContent.Networks[0].Flags)
@@ -55,7 +56,7 @@ func TestGenerateRawNetworkEgressRule_2(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortMatch))
@@ -77,7 +78,7 @@ func TestGenerateRawNetworkEgressRule_3(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PortMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match))
@@ -99,7 +100,7 @@ func TestGenerateRawNetworkEgressRule_4(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PortRangeMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match))
@@ -127,7 +128,7 @@ func TestGenerateRawNetworkEgressRule_5(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PortsMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match))
@@ -150,7 +151,7 @@ func TestGenerateRawNetworkEgressRule_6(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortRangeMatch))
@@ -180,7 +181,7 @@ func TestGenerateRawNetworkEgressRule_7(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortsMatch))
@@ -199,7 +200,7 @@ func TestGenerateRawNetworkEgressRule_8(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 2)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortsMatch))
@@ -235,7 +236,7 @@ func TestGenerateRawNetworkEgressRule_9(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 2)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.CidrMatch|bpfenforcer.PortRangeMatch))
@@ -278,7 +279,7 @@ func TestGenerateRawNetworkEgressRule_10(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 3)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortRangeMatch))
@@ -315,7 +316,7 @@ func TestGenerateRawNetworkEgressRule_11(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PreciseMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match|bpfenforcer.PortsMatch))
@@ -338,7 +339,7 @@ func TestGenerateRawNetworkEgressRule_12(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	_, err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false)
+	err := generateRawNetworkEgressRule(nil, bpfContent, 0, &rule, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PodSelfIpMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match|bpfenforcer.PortMatch))

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -64,7 +64,7 @@ func GenerateProfile(
 	logger logr.Logger) (*varmor.Profile, *varmortypes.EgressInfo, error) {
 	var err error
 
-	var egressInfo *varmortypes.EgressInfo
+	var egressInfo varmortypes.EgressInfo
 
 	profile := varmor.Profile{
 		Name:     name,
@@ -141,7 +141,7 @@ func GenerateProfile(
 		// BPF
 		if (e & varmortypes.BPF) != 0 {
 			var bpfContent varmor.BpfContent
-			egressInfo, err = bpfprofile.GenerateEnhanceProtectProfile(kubeClient, policy.EnhanceProtect, &bpfContent, enablePodServiceEgressControl)
+			err = bpfprofile.GenerateEnhanceProtectProfile(kubeClient, policy.EnhanceProtect, &bpfContent, enablePodServiceEgressControl, &egressInfo)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -268,7 +268,7 @@ func GenerateProfile(
 		return nil, nil, fmt.Errorf("unknown mode")
 	}
 
-	return &profile, egressInfo, nil
+	return &profile, &egressInfo, nil
 }
 
 func NewArmorProfile(

--- a/tools/policy-advisor/built-in-rules.json
+++ b/tools/policy-advisor/built-in-rules.json
@@ -702,6 +702,10 @@
         "syscalls": ["splice"]
       },
       "applicable": {}
+    },
+    {
+      "id": "ingress-nightmare-mitigation",
+      "enforcers": ["bpf"]
     }
   ]
 }

--- a/tools/policy-advisor/built-in-rules.json
+++ b/tools/policy-advisor/built-in-rules.json
@@ -583,7 +583,7 @@
       }
     },
     {
-      "id": "disallow-metadata-service",
+      "id": "block-access-to-metadata-service",
       "enforcers": ["bpf"]
     }
   ],
@@ -654,6 +654,19 @@
       "enforcers": ["apparmor", "bpf"],
       "conflicts": {
         "executions": ["su", "sudo"]
+      }
+    },
+    {
+      "id": "block-access-to-kube-apiserver",
+      "enforcers": ["bpf"],
+      "conflicts": {
+        "features": ["require-sa"],
+        "files": [
+          {
+            "path_regex": "\/run\/secrets\/kubernetes.io\/serviceaccount\/",
+            "permissions": ["r"]
+          }
+        ]
       }
     }
   ],

--- a/website/static/built-in-rules.json
+++ b/website/static/built-in-rules.json
@@ -702,6 +702,10 @@
         "syscalls": ["splice"]
       },
       "applicable": {}
+    },
+    {
+      "id": "ingress-nightmare-mitigation",
+      "enforcers": ["bpf"]
     }
   ]
 }

--- a/website/static/built-in-rules.json
+++ b/website/static/built-in-rules.json
@@ -583,7 +583,7 @@
       }
     },
     {
-      "id": "disallow-metadata-service",
+      "id": "block-access-to-metadata-service",
       "enforcers": ["bpf"]
     }
   ],
@@ -654,6 +654,19 @@
       "enforcers": ["apparmor", "bpf"],
       "conflicts": {
         "executions": ["su", "sudo"]
+      }
+    },
+    {
+      "id": "block-access-to-kube-apiserver",
+      "enforcers": ["bpf"],
+      "conflicts": {
+        "features": ["require-sa"],
+        "files": [
+          {
+            "path_regex": "\/run\/secrets\/kubernetes.io\/serviceaccount\/",
+            "permissions": ["r"]
+          }
+        ]
       }
     }
   ],


### PR DESCRIPTION
# What this PR does

This PR adds two built-in rules:  
- **block-access-to-kube-apiserver**: Prevents containers from directly accessing the Kubernetes API server.  
- **ingress-nightmare-mitigation**: Mitigates CVE-2025-1974 (IngressNightmare) by blocking exploitable traffic patterns.  

# What type of PR is this?
/kind feature

