### PR TITLE
Inject Cluster Metadata into Component Logs for Centralized Analysis

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	rest "k8s.io/client-go/rest"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
+
+	varmorauditor "github.com/bytedance/vArmor/pkg/auditor"
 )
 
 var (
@@ -133,6 +135,9 @@ var (
 
 	// ArmorProfileModelDataDirectory saves the ArmorProfileModel objects in the manager pod
 	ArmorProfileModelDataDirectory = "/var/log/varmor/apmdata"
+
+	// AuditEventMetadata caches the cluster metadata that can be injected into the logs
+	AuditEventMetadata = varmorauditor.LoadAuditEventMetadata()
 )
 
 // CreateClientConfig creates client config and applies rate limit QPS and burst

--- a/manifests/varmor/templates/daemonsets/agent.yaml
+++ b/manifests/varmor/templates/daemonsets/agent.yaml
@@ -40,18 +40,6 @@ spec:
         image: "{{ .Values.image.registry }}/{{ .Values.image.namespace }}/{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
         command: ["/varmor/vArmor", "--agent"]
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
-        - name: READINESS_PORT
-          value: "{{ .Values.agent.network.readinessPort }}"
-        {{- if .Values.auditEventMetadata }}
-        - name: AUDIT_EVENT_METADATA
-          value: '{{- toJson .Values.auditEventMetadata}}'
-        {{- end }}
         {{- if or .Values.jsonLogFormat.enabled .Values.agent.args .Values.behaviorModeling.enabled .Values.bpfLsmEnforcer.enabled .Values.unloadAllAaProfiles.enabled .Values.removeAllSeccompProfiles.enabled }}
         args:
           {{- if .Values.jsonLogFormat.enabled }}
@@ -84,6 +72,18 @@ spec:
               {{- toYaml . | nindent 8 }}
             {{- end }}
           {{- end }}
+        {{- end }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: READINESS_PORT
+          value: "{{ .Values.agent.network.readinessPort }}"
+        {{- if .Values.auditEventMetadata }}
+        - name: AUDIT_EVENT_METADATA
+          value: '{{- toJson .Values.auditEventMetadata}}'
         {{- end }}
         securityContext:
           {{- with .Values.agent.securityContext }}

--- a/manifests/varmor/templates/deployments/manager.yaml
+++ b/manifests/varmor/templates/deployments/manager.yaml
@@ -80,6 +80,11 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
+        {{- if .Values.auditEventMetadata }}
+        env:
+        - name: AUDIT_EVENT_METADATA
+          value: '{{- toJson .Values.auditEventMetadata}}'
+        {{- end }}
         securityContext:
           {{- toYaml .Values.manager.securityContext | nindent 10 }}
         ports:

--- a/manifests/varmor/values.yaml
+++ b/manifests/varmor/values.yaml
@@ -49,7 +49,7 @@ auditEventMetadata:
   # For example, you can add the cluster id, name, region, or any other information that is relevant to your environment.
   # clusterId: "ccvbve8igndqr18dnk0vg"
   # clusterName: "production-cluster-1"
-  # clusterRegion: "cn-beijing"
+  # region: "cn-beijing"
 
 image:
   registry: ""

--- a/pkg/auditor/auditor.go
+++ b/pkg/auditor/auditor.go
@@ -83,7 +83,7 @@ func NewAuditor(nodeName string, appArmorSupported, bpfLsmSupported, enableBehav
 		filePermissionMap:      initFilePermissionMap(),
 		ptracePermissionMap:    initPtracePermissionMap(),
 		mountFlagMap:           initMountFlagMap(),
-		auditEventMetadata:     loadAuditEventMetadata(),
+		auditEventMetadata:     LoadAuditEventMetadata(),
 		log:                    log,
 	}
 

--- a/pkg/auditor/utils.go
+++ b/pkg/auditor/utils.go
@@ -179,7 +179,7 @@ func initMountFlagMap() map[uint32]string {
 	}
 }
 
-func loadAuditEventMetadata() map[string]string {
+func LoadAuditEventMetadata() map[string]string {
 	metadata := make(map[string]string)
 	s := os.Getenv(metadataJSONEnv)
 	if s != "" {


### PR DESCRIPTION
# What this PR does 
Enhances logging across vArmor components by injecting cluster metadata (accountId, region, clusterId, clusterName) into log outputs, enabling easy differentiation of logs from multiple clusters in centralized analysis systems.  

# Main Code Changes  
- Added metadata injection from `AuditEventMetadata` config into all log entries  
- Replaced static `setupLog` with dynamic logger (`logger`) configured with metadata  
- Propagated metadata-enriched logger to all subsystems (setup, policy cacher, webhook, controller, etc.)  

# Benefits
- Simplifies log correlation in multi-tenant and multi-cluster environments  
- Improves observability for security and operational analysis

# Notes  
Metadata (accountId, region, clusterId, clusterName) must be configured via the `AuditEventMetadata` Helm values  