### PR TITLE
feat: Add container image to audit events

### DIFF
--- a/pkg/auditor/audit.go
+++ b/pkg/auditor/audit.go
@@ -67,11 +67,12 @@ func (auditor *Auditor) processAuditEvent(event string) {
 
 		info := auditor.containerCache[mntNsID]
 		auditor.log.V(2).Info("audit event",
-			"container id", info.ContainerID,
-			"container name", info.ContainerName,
+			"pod uid", info.PodUID,
 			"pod name", info.PodName,
 			"pod namespace", info.PodNamespace,
-			"pod uid", info.PodUID,
+			"container id", info.ContainerID,
+			"container name", info.ContainerName,
+			"image", info.Image,
 			"pid", e.PID, "time", e.Epoch, "event", strings.TrimSpace(event))
 
 		// Try to parse the AppArmor profile name from the event
@@ -86,6 +87,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Str("podNamespace", info.PodNamespace).
 				Str("containerID", info.ContainerID).
 				Str("containerName", info.ContainerName).
+				Str("image", info.Image).
 				Uint32("pid", uint32(e.PID)).
 				Uint32("mntNsID", mntNsID).
 				Uint64("eventTimestamp", uint64(e.Epoch)).
@@ -106,6 +108,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Str("podNamespace", info.PodNamespace).
 				Str("containerID", info.ContainerID).
 				Str("containerName", info.ContainerName).
+				Str("image", info.Image).
 				Uint32("pid", uint32(e.PID)).
 				Uint32("mntNsID", mntNsID).
 				Uint64("eventTimestamp", uint64(e.Epoch)).
@@ -148,11 +151,12 @@ func (auditor *Auditor) processAuditEvent(event string) {
 
 			info := auditor.containerCache[mntNsID]
 			auditor.log.V(2).Info("audit event",
-				"container id", info.ContainerID,
-				"container name", info.ContainerName,
+				"pod uid", info.PodUID,
 				"pod name", info.PodName,
 				"pod namespace", info.PodNamespace,
-				"pod uid", info.PodUID,
+				"container id", info.ContainerID,
+				"container name", info.ContainerName,
+				"image", info.Image,
 				"pid", e.PID, "time", e.Epoch, "event", strings.TrimSpace(event))
 
 			// Try to parse the AppArmor profile name from the event
@@ -176,6 +180,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Str("podNamespace", info.PodNamespace).
 				Str("containerID", info.ContainerID).
 				Str("containerName", info.ContainerName).
+				Str("image", info.Image).
 				Uint32("pid", uint32(e.PID)).
 				Uint32("mntNsID", mntNsID).
 				Uint64("eventTimestamp", e.Epoch).

--- a/pkg/auditor/bpf.go
+++ b/pkg/auditor/bpf.go
@@ -157,11 +157,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			e = auditor.convertBpfEvent(bpfenforcer.CapabilityType, &event)
 
 			auditor.log.V(2).Info("audit event",
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
 				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
 				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
+				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
+				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"image", auditor.containerCache[eventHeader.MntNs].Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"capability", event.Capability)
 
@@ -177,11 +178,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			e = auditor.convertBpfEvent(bpfenforcer.FileType, &event)
 
 			auditor.log.V(2).Info("audit event",
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
 				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
 				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
+				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
+				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"image", auditor.containerCache[eventHeader.MntNs].Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"path", unix.ByteSliceToString(event.Path[:]), "permissions", event.Permissions)
 
@@ -197,11 +199,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			e = auditor.convertBpfEvent(bpfenforcer.BprmType, &event)
 
 			auditor.log.V(2).Info("audit event",
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
 				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
 				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
+				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
+				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"image", auditor.containerCache[eventHeader.MntNs].Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"path", unix.ByteSliceToString(event.Path[:]), "permissions", event.Permissions)
 
@@ -219,22 +222,24 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			switch event.Type {
 			case bpfenforcer.SocketType:
 				auditor.log.V(2).Info("audit event",
-					"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-					"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+					"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
 					"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
 					"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-					"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
+					"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
+					"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+					"image", auditor.containerCache[eventHeader.MntNs].Image,
 					"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 					"domain", e.(*BpfNetworkCreateEvent).Domain,
 					"type", e.(*BpfNetworkCreateEvent).Type,
 					"protocol", e.(*BpfNetworkCreateEvent).Protocol)
 			case bpfenforcer.ConnectType:
 				auditor.log.V(2).Info("audit event",
-					"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-					"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+					"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
 					"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
 					"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-					"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
+					"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
+					"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+					"image", auditor.containerCache[eventHeader.MntNs].Image,
 					"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 					"address", e.(*BpfNetworkConnectEvent).IP, "port", e.(*BpfNetworkConnectEvent).Port)
 			}
@@ -251,11 +256,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			e = auditor.convertBpfEvent(bpfenforcer.PtraceType, &event)
 
 			auditor.log.V(2).Info("audit event",
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
 				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
 				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
+				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
+				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"image", auditor.containerCache[eventHeader.MntNs].Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"permissions", event.Permissions, "externel", event.External)
 
@@ -271,11 +277,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			e = auditor.convertBpfEvent(bpfenforcer.MountType, &event)
 
 			auditor.log.V(2).Info("audit event",
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
 				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
 				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
+				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
+				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
+				"image", auditor.containerCache[eventHeader.MntNs].Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"Device Name:", unix.ByteSliceToString(event.DevName[:]),
 				"FileSystem Type:", unix.ByteSliceToString(event.Type[:]), "Flags:", event.Flags)
@@ -292,6 +299,7 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 				Str("podNamespace", auditor.containerCache[eventHeader.MntNs].PodNamespace).
 				Str("containerID", auditor.containerCache[eventHeader.MntNs].ContainerID).
 				Str("containerName", auditor.containerCache[eventHeader.MntNs].ContainerName).
+				Str("image", auditor.containerCache[eventHeader.MntNs].Image).
 				Uint32("pid", eventHeader.Tgid).
 				Uint32("mntNsID", eventHeader.MntNs).
 				Uint64("eventTimestamp", eventHeader.Ktime/uint64(time.Second)+auditor.bootTimestamp).
@@ -310,6 +318,7 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 				Str("podNamespace", auditor.containerCache[eventHeader.MntNs].PodNamespace).
 				Str("containerID", auditor.containerCache[eventHeader.MntNs].ContainerID).
 				Str("containerName", auditor.containerCache[eventHeader.MntNs].ContainerName).
+				Str("image", auditor.containerCache[eventHeader.MntNs].Image).
 				Uint32("pid", eventHeader.Tgid).
 				Uint32("mntNsID", eventHeader.MntNs).
 				Uint64("eventTimestamp", eventHeader.Ktime/uint64(time.Second)+auditor.bootTimestamp).

--- a/pkg/runtime/monitor.go
+++ b/pkg/runtime/monitor.go
@@ -144,6 +144,8 @@ func (monitor *RuntimeMonitor) retrieveContainerInfo(containerInfo *varmortypes.
 		return fmt.Errorf("spec.Annotations['io.kubernetes.cri.container-name] isn't exist")
 	}
 
+	containerInfo.Image = info.Image
+
 	return nil
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -38,10 +38,11 @@ type ContainerInfo struct {
 	ContainerID    string
 	ContainerName  string
 	PodID          string
+	PodUID         string
 	PodName        string
 	PodNamespace   string
-	PodUID         string
 	PodIPs         []string
 	PodAnnotations map[string]string
+	Image          string
 	ProfileName    string
 }


### PR DESCRIPTION
# What this PR does?
It injects container image into vArmor's audit events, enhancing observability.

# What type of PR is this?
/kind feature

# Main Code Changes
* Container monitor caches the container image.
* Auditor inject the image into the audit event.

# Benefits
* Improves incident response by adding contextual information