### PR TITLE
Add built-in rule 'block-access-to-container-runtime' for runtime socket protection

### DIFF
--- a/internal/profile/apparmor/rules.go
+++ b/internal/profile/apparmor/rules.go
@@ -345,6 +345,10 @@ func generateAttackProtectionRules(rule, qualifier string, allowViolations bool)
 		rules += qualifier + "network tcp,\n"
 	case "disable-udp":
 		rules += qualifier + "network udp,\n"
+	case "block-access-to-container-runtime":
+		rules += qualifier + "/**/containerd.sock rw,\n"
+		rules += qualifier + "/**/docker.sock rw,\n"
+		rules += qualifier + "/**/crio.sock rw,\n"
 	}
 	return rules
 }

--- a/internal/profile/bpf/bpf.go
+++ b/internal/profile/bpf/bpf.go
@@ -634,6 +634,24 @@ func generateAttackProtectionRules(
 				egressInfo.ToServices = append(egressInfo.ToServices, *service)
 			}
 		}
+	case "block-access-to-container-runtime":
+		fileContent, err = newBpfPathRule(mode, "/**/containerd.sock", bpfenforcer.AaMayRead|bpfenforcer.AaMayWrite|bpfenforcer.AaMayAppend)
+		if err != nil {
+			return err
+		}
+		content.Files = append(content.Files, *fileContent)
+
+		fileContent, err = newBpfPathRule(mode, "/**/docker.sock", bpfenforcer.AaMayRead|bpfenforcer.AaMayWrite|bpfenforcer.AaMayAppend)
+		if err != nil {
+			return err
+		}
+		content.Files = append(content.Files, *fileContent)
+
+		fileContent, err = newBpfPathRule(mode, "/**/crio.sock", bpfenforcer.AaMayRead|bpfenforcer.AaMayWrite|bpfenforcer.AaMayAppend)
+		if err != nil {
+			return err
+		}
+		content.Files = append(content.Files, *fileContent)
 	}
 	return nil
 }

--- a/tools/policy-advisor/built-in-rules.json
+++ b/tools/policy-advisor/built-in-rules.json
@@ -668,6 +668,19 @@
           }
         ]
       }
+    },
+    {
+      "id": "block-access-to-container-runtime",
+      "enforcers": ["apparmor", "bpf"],
+      "conflicts": {
+        "features": ["dind"],
+        "files": [
+          {
+            "path_regex": "\/containerd.sock|\/docker.sock|\/crio.sock",
+            "permissions": ["r", "w", "a"]
+          }
+        ]
+      }
     }
   ],
   "vulnerability_mitigation": [

--- a/website/static/built-in-rules.json
+++ b/website/static/built-in-rules.json
@@ -668,6 +668,19 @@
           }
         ]
       }
+    },
+    {
+      "id": "block-access-to-container-runtime",
+      "enforcers": ["apparmor", "bpf"],
+      "conflicts": {
+        "features": ["dind"],
+        "files": [
+          {
+            "path_regex": "\/containerd.sock|\/docker.sock|\/crio.sock",
+            "permissions": ["r", "w", "a"]
+          }
+        ]
+      }
     }
   ],
   "vulnerability_mitigation": [


### PR DESCRIPTION
# What this PR does
Introduces a new built-in security rule `block-access-to-container-runtime` to mitigate privilege escalation risks by prohibiting access to critical container runtime sockets.

# Main Code Changes
- Added rule to block access to core runtime Unix domain sockets:  
  - `docker.sock` (Docker runtime)  
  - `containerd.sock` (containerd runtime)  
  - `crio.sock` (CRI-O runtime)  
- Integrated rule into the policy advisor.

# Benefits
Blocks critical attack chain step for leveraging runtime sockets to gain host/cluster access  (See [How Wiz found a Critical NVIDIA AI vulnerability:  Deep Dive into a container escape (CVE-2024-0132)](https://www.wiz.io/blog/nvidia-ai-vulnerability-deep-dive-cve-2024-0132)