### PR TITLE
Mode Switching Enhancement

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -425,49 +425,33 @@ func (agent *Agent) handleCreateOrUpdateArmorProfile(ap *varmor.ArmorProfile, ke
 
 	// [Experimental feature] For BehaviorModeling mode,
 	// only works with AppArmor/Seccomp/AppArmorSeccomp enforcer for now.
-	needLoadApparmor := true
-	if agent.enableBehaviorModeling &&
-		ap.Spec.BehaviorModeling.Enable &&
-		ap.Spec.BehaviorModeling.Duration != 0 {
-
+	if agent.enableBehaviorModeling {
 		createTime := ap.CreationTimestamp.Time
 		Duration := time.Duration(ap.Spec.BehaviorModeling.Duration) * time.Minute
 
-		if modeller, ok := agent.modellers[key]; ok {
-			needLoadApparmor = false
-			// Update a running modeller's duration.
+		modeller, exist := agent.modellers[key]
+		if exist && modeller.IsModeling() {
 			modeller.UpdateDuration(Duration)
-			if !modeller.IsModeling() {
-				// Sync data to manager immediately.
-				modeller.PreprocessAndSendBehaviorData()
-			}
 		} else {
-			// Create a new modeller and start modeling for the ArmorProfile object.
-			modeller := varmorbehavior.NewBehaviorModeller(
-				agent.auditor,
-				agent.ptracer,
-				agent.monitor,
-				agent.nodeName,
-				ap.Namespace,
-				ap.Name,
-				ap.Spec.Profile.Enforcer,
-				createTime,
-				Duration,
-				agent.stopCh,
-				agent.svcAddresses,
-				agent.debug,
-				agent.inContainer,
-				agent.log.WithName("BEHAVIOR-MODELLER"))
-			if modeller != nil {
+			if time.Now().Before(createTime.Add(Duration)) {
+				// Create a new modeller and start modeling for the ArmorProfile object.
+				modeller = varmorbehavior.NewBehaviorModeller(
+					agent.auditor,
+					agent.ptracer,
+					agent.monitor,
+					agent.nodeName,
+					ap.Namespace,
+					ap.Name,
+					ap.Spec.Profile.Enforcer,
+					createTime,
+					Duration,
+					agent.stopCh,
+					agent.svcAddresses,
+					agent.debug,
+					agent.inContainer,
+					agent.log.WithName("BEHAVIOR-MODELLER"))
 				agent.modellers[key] = modeller
-
-				if time.Now().Before(createTime.Add(Duration)) {
-					// Start modeling, sync data to manager when modeling completed.
-					modeller.Run()
-				} else {
-					// Sync data to manager immediately.
-					modeller.PreprocessAndSendBehaviorData()
-				}
+				modeller.Run()
 			}
 		}
 	}
@@ -477,30 +461,28 @@ func (agent *Agent) handleCreateOrUpdateArmorProfile(ap *varmor.ArmorProfile, ke
 	// AppArmor
 	if (enforcer & varmortypes.AppArmor) != 0 {
 		// Save and load AppArmor profile.
-		if needLoadApparmor {
-			logger.Info(fmt.Sprintf("saving the AppArmor profile '%s (%s)' to Node/%s", ap.Spec.Profile.Name, ap.Spec.Profile.Mode, agent.nodeName))
-			profilePath := filepath.Join(agent.appArmorProfileDir, ap.Spec.Profile.Name)
-			err := varmorapparmor.SaveAppArmorProfile(profilePath, ap.Spec.Profile.Content)
-			if err != nil {
-				logger.Error(err, "SaveAppArmorProfile()")
-				errorMessages = append(errorMessages, "SaveAppArmorProfile(): "+err.Error())
+		logger.Info(fmt.Sprintf("saving the AppArmor profile '%s (%s)' to Node/%s", ap.Spec.Profile.Name, ap.Spec.Profile.Mode, agent.nodeName))
+		profilePath := filepath.Join(agent.appArmorProfileDir, ap.Spec.Profile.Name)
+		err := varmorapparmor.SaveAppArmorProfile(profilePath, ap.Spec.Profile.Content)
+		if err != nil {
+			logger.Error(err, "SaveAppArmorProfile()")
+			errorMessages = append(errorMessages, "SaveAppArmorProfile(): "+err.Error())
+		} else {
+			if yes, _ := varmorapparmor.IsAppArmorProfileLoaded(ap.Spec.Profile.Name); !yes {
+				// Load a new AppArmor profile to kernel for ArmorProfile creation event.
+				logger.Info(fmt.Sprintf("loading '%s (%s)' to Node/%s's kernel", ap.Spec.Profile.Name, ap.Spec.Profile.Mode, agent.nodeName))
+				output, err := varmorapparmor.LoadAppArmorProfile(profilePath, string(ap.Spec.Profile.Mode))
+				if err != nil {
+					logger.Error(err, "LoadAppArmorProfile()", "output", output)
+					errorMessages = append(errorMessages, "LoadAppArmorProfile(): "+err.Error()+"  output: "+output)
+				}
 			} else {
-				if yes, _ := varmorapparmor.IsAppArmorProfileLoaded(ap.Spec.Profile.Name); !yes {
-					// Load a new AppArmor profile to kernel for ArmorProfile creation event.
-					logger.Info(fmt.Sprintf("loading '%s (%s)' to Node/%s's kernel", ap.Spec.Profile.Name, ap.Spec.Profile.Mode, agent.nodeName))
-					output, err := varmorapparmor.LoadAppArmorProfile(profilePath, string(ap.Spec.Profile.Mode))
-					if err != nil {
-						logger.Error(err, "LoadAppArmorProfile()", "output", output)
-						errorMessages = append(errorMessages, "LoadAppArmorProfile(): "+err.Error()+"  output: "+output)
-					}
-				} else {
-					// Update a existing AppArmor profile for ArmorProfile update event.
-					logger.Info(fmt.Sprintf("reloading '%s (%s)' to Node/%s's kernel", ap.Spec.Profile.Name, ap.Spec.Profile.Mode, agent.nodeName))
-					output, err := varmorapparmor.UpdateAppArmorProfile(profilePath, string(ap.Spec.Profile.Mode))
-					if err != nil {
-						logger.Error(err, "UpdateAppArmorProfile()", "output", output)
-						errorMessages = append(errorMessages, "UpdateAppArmorProfile(): "+err.Error()+"  output: "+output)
-					}
+				// Update a existing AppArmor profile for ArmorProfile update event.
+				logger.Info(fmt.Sprintf("reloading '%s (%s)' to Node/%s's kernel", ap.Spec.Profile.Name, ap.Spec.Profile.Mode, agent.nodeName))
+				output, err := varmorapparmor.UpdateAppArmorProfile(profilePath, string(ap.Spec.Profile.Mode))
+				if err != nil {
+					logger.Error(err, "UpdateAppArmorProfile()", "output", output)
+					errorMessages = append(errorMessages, "UpdateAppArmorProfile(): "+err.Error()+"  output: "+output)
 				}
 			}
 		}

--- a/internal/behavior/modeller.go
+++ b/internal/behavior/modeller.go
@@ -104,9 +104,9 @@ func NewBehaviorModeller(
 		return nil
 	}
 
-	ProcessRecorder := varmorrecorder.NewProcessRecorder(varmorconfig.AuditDataDirectory, name, stopCh, debug, log.WithName("BPF-RECORDER"))
-	if ProcessRecorder != nil {
-		modeller.processRecorder = ProcessRecorder
+	processRecorder := varmorrecorder.NewProcessRecorder(varmorconfig.AuditDataDirectory, name, stopCh, debug, log.WithName("BPF-RECORDER"))
+	if processRecorder != nil {
+		modeller.processRecorder = processRecorder
 	} else {
 		return nil
 	}

--- a/internal/behavior/modeller.go
+++ b/internal/behavior/modeller.go
@@ -75,43 +75,29 @@ func NewBehaviorModeller(
 	log.Info("create a behavior modeller", "start time", startTime,
 		"duration", duration.String(), "profile name", name)
 
-	modeller := BehaviorModeller{
-		auditor:        auditor,
-		ptracer:        ptracer,
-		monitor:        monitor,
-		nodeName:       nodeName,
-		namespace:      namespace,
-		name:           name,
-		enforcer:       enforcer,
-		startTime:      startTime,
-		duration:       duration,
-		modeling:       false,
-		TaskStartCh:    make(chan varmortypes.ContainerInfo, 100),
-		targetPIDs:     make(map[uint32]struct{}, 500),
-		targetMnts:     make(map[uint32]struct{}, 30),
-		ModellerStopCh: make(chan bool, 1),
-		stopCh:         stopCh,
-		svcAddresses:   svcAddresses,
-		debug:          debug,
-		inContainer:    inContainer,
-		log:            log,
+	return &BehaviorModeller{
+		auditor:         auditor,
+		ptracer:         ptracer,
+		monitor:         monitor,
+		nodeName:        nodeName,
+		namespace:       namespace,
+		name:            name,
+		enforcer:        enforcer,
+		startTime:       startTime,
+		duration:        duration,
+		modeling:        false,
+		TaskStartCh:     make(chan varmortypes.ContainerInfo, 100),
+		targetPIDs:      make(map[uint32]struct{}, 500),
+		targetMnts:      make(map[uint32]struct{}, 30),
+		auditRecorder:   varmorrecorder.NewAuditRecorder(varmorconfig.AuditDataDirectory, name, stopCh, debug, log.WithName("AUDIT-RECORDER")),
+		processRecorder: varmorrecorder.NewProcessRecorder(varmorconfig.AuditDataDirectory, name, stopCh, debug, log.WithName("BPF-RECORDER")),
+		ModellerStopCh:  make(chan bool, 1),
+		stopCh:          stopCh,
+		svcAddresses:    svcAddresses,
+		debug:           debug,
+		inContainer:     inContainer,
+		log:             log,
 	}
-
-	auditRecorder := varmorrecorder.NewAuditRecorder(varmorconfig.AuditDataDirectory, name, stopCh, debug, log.WithName("AUDIT-RECORDER"))
-	if auditRecorder != nil {
-		modeller.auditRecorder = auditRecorder
-	} else {
-		return nil
-	}
-
-	processRecorder := varmorrecorder.NewProcessRecorder(varmorconfig.AuditDataDirectory, name, stopCh, debug, log.WithName("BPF-RECORDER"))
-	if processRecorder != nil {
-		modeller.processRecorder = processRecorder
-	} else {
-		return nil
-	}
-
-	return &modeller
 }
 
 func (modeller *BehaviorModeller) PreprocessAndSendBehaviorData() {
@@ -176,6 +162,15 @@ func (modeller *BehaviorModeller) shouldCacheContainer(info varmortypes.Containe
 }
 
 func (modeller *BehaviorModeller) eventHandler() {
+	stopAndCleanup := func() {
+		modeller.stop()
+		modeller.auditRecorder.Close()
+		modeller.auditRecorder.CleanUp()
+		modeller.processRecorder.Close()
+		modeller.processRecorder.CleanUp()
+		modeller.log.Info("behavioral data collection is stopped", "profile name", modeller.name)
+	}
+
 	ticker := time.NewTicker(30 * time.Second)
 
 	for {
@@ -211,17 +206,11 @@ func (modeller *BehaviorModeller) eventHandler() {
 			}
 
 		case <-modeller.stopCh:
-			modeller.stop()
-			modeller.log.Info("behavioral data collection is stopped", "profile name", modeller.name)
+			stopAndCleanup()
 			return
 
 		case <-modeller.ModellerStopCh:
-			modeller.stop()
-			modeller.auditRecorder.Close()
-			modeller.auditRecorder.CleanUp()
-			modeller.processRecorder.Close()
-			modeller.processRecorder.CleanUp()
-			modeller.log.Info("behavioral data collection is stopped", "profile name", modeller.name)
+			stopAndCleanup()
 			return
 		}
 	}

--- a/internal/policy/clusterpolicy_controller.go
+++ b/internal/policy/clusterpolicy_controller.go
@@ -188,44 +188,44 @@ func (c *ClusterPolicyController) handleDeleteVarmorClusterPolicy(name string) e
 
 func (c *ClusterPolicyController) ignoreAdd(vcp *varmor.VarmorClusterPolicy, logger logr.Logger) (bool, error) {
 	if vcp.Spec.Target.Kind != "Deployment" && vcp.Spec.Target.Kind != "StatefulSet" && vcp.Spec.Target.Kind != "DaemonSet" && vcp.Spec.Target.Kind != "Pod" {
-		err := fmt.Errorf("Target.Kind is not supported")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		err := fmt.Errorf("the target kind is not supported")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, vcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"This kind of target is not supported.")
+			"The target kind is not supported.")
 		return true, err
 	}
 
 	if vcp.Spec.Target.Name == "" && vcp.Spec.Target.Selector == nil {
-		err := fmt.Errorf("target.Name and target.Selector are empty")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		err := fmt.Errorf("the target name and selector are empty")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, vcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"You should specify the target workload by name or selector.")
+			"You should specify the target workload either by name or selector.")
 		return true, err
 	}
 
 	if vcp.Spec.Target.Name != "" && vcp.Spec.Target.Selector != nil {
-		err := fmt.Errorf("target.Name and target.Selector are exclusive")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		err := fmt.Errorf("the target name and selector are exclusive")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, vcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"You shouldn't specify the target workload by both name and selector.")
+			"You shouldn't specify the target workload using both name and selector.")
 		return true, err
 	}
 
 	if vcp.Spec.Policy.Mode == varmor.EnhanceProtectMode && vcp.Spec.Policy.EnhanceProtect == nil {
-		err := fmt.Errorf("the EnhanceProtect field is not set when running in the EnhanceProtect mode")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		err := fmt.Errorf("the enhanceProtect field is not set when the policy runs in the EnhanceProtect mode")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, vcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"The EnhanceProtect field should be set when running in the EnhanceProtect mode.")
+			"The enhanceProtect field should be set when the policy runs in the EnhanceProtect mode.")
 		return true, err
 	}
 
 	if !c.enableBehaviorModeling && vcp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
 		err := fmt.Errorf("the BehaviorModeling mode is not enabled")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, vcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
 			"The BehaviorModeling feature is not enabled.")
@@ -233,11 +233,11 @@ func (c *ClusterPolicyController) ignoreAdd(vcp *varmor.VarmorClusterPolicy, log
 	}
 
 	if c.enableBehaviorModeling && vcp.Spec.Policy.Mode == varmor.BehaviorModelingMode && vcp.Spec.Policy.ModelingOptions == nil {
-		err := fmt.Errorf("the ModelingOptions field is not set when running in the BehaviorModeling mode")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		err := fmt.Errorf("the modelingOptions field is not set when the policy runs in the BehaviorModeling mode")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, vcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"The ModelingOptions field should be set when running in the BehaviorModeling mode.")
+			"The modelingOptions field should be set when the policy runs in the BehaviorModeling mode.")
 		return true, err
 	}
 
@@ -246,8 +246,8 @@ func (c *ClusterPolicyController) ignoreAdd(vcp *varmor.VarmorClusterPolicy, log
 	profileName := varmorprofile.GenerateArmorProfileName(varmorconfig.Namespace, vcp.Name, true)
 	if len(profileName) > 63 {
 		err := fmt.Errorf("the length of ArmorProfile name is exceed 63. name: %s, length: %d", profileName, len(profileName))
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
-		msg := fmt.Sprintf("The length of VarmorClusterPolicy object name is too long, please limit it to %d bytes.", 63-len(varmorprofile.ClusterProfileNameTemplate)+4-len(varmorconfig.Namespace))
+		logger.Error(err, "update the policy status with forbidden info")
+		msg := fmt.Sprintf("The length of policy object name is too long, please limit it to %d bytes.", 63-len(varmorprofile.ClusterProfileNameTemplate)+4-len(varmorconfig.Namespace))
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, vcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
 			msg)
@@ -338,81 +338,51 @@ func (c *ClusterPolicyController) handleAddVarmorClusterPolicy(vcp *varmor.Varmo
 }
 
 func (c *ClusterPolicyController) ignoreUpdate(newVcp *varmor.VarmorClusterPolicy, oldAp *varmor.ArmorProfile, logger logr.Logger) (bool, error) {
-	// Disallow modifying the target of VarmorClusterPolicy.
-	if !reflect.DeepEqual(newVcp.Spec.Target, oldAp.Spec.Target) {
-		err := fmt.Errorf("disallow modifying spec.target")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
-		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-			"Forbidden",
-			"Modifying the target of VarmorClusterPolicy is not allowed. You need to recreate the VarmorClusterPolicy object.")
-		return true, err
-	}
-
-	// Disallow switching the mode from others to BehaviorModeling.
-	if newVcp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
-		oldAp.Spec.BehaviorModeling.Duration == 0 {
-		err := fmt.Errorf("disallow switching spec.policy.mode from others to BehaviorModeling")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
-		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-			"Forbidden",
-			"Switching the mode from others to BehaviorModeling is not allowed. You need to recreate the VarmorClusterPolicy object.")
-		return true, err
-	}
-
-	// Disallow switching the mode from BehaviorModeling to others when behavior modeling is still incomplete.
-	if newVcp.Spec.Policy.Mode != varmor.BehaviorModelingMode &&
-		newVcp.Status.Phase == varmor.VarmorPolicyModeling {
-		err := fmt.Errorf("disallow switching spec.policy.mode from BehaviorModeling to others when behavior modeling is still incomplete")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
-		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-			"Forbidden",
-			"Switching the mode from BehaviorModeling to others is not allowed when behavior modeling is still incomplete. You need to recreate the VarmorClusterPolicy object.")
-		return true, err
-	}
-
-	// Disallow shutting down the activated AppArmor or Seccomp enforcer.
 	newEnforcers := varmortypes.GetEnforcerType(newVcp.Spec.Policy.Enforcer)
 	oldEnforcers := varmortypes.GetEnforcerType(oldAp.Spec.Profile.Enforcer)
-	if (newEnforcers&oldEnforcers != oldEnforcers) && (newEnforcers|varmortypes.BPF != oldEnforcers) {
-		err := fmt.Errorf("disallow shutting down the activated AppArmor or Seccomp enforcer")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+
+	// Disallow modifying the target field of a policy.
+	if !reflect.DeepEqual(newVcp.Spec.Target, oldAp.Spec.Target) {
+		err := fmt.Errorf("disallow modifying the target field of a policy")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"Modifying a policy to remove the AppArmor or Seccomp enforcer is not allowed. To remove them, you need to recreate the VarmorClusterPolicy object.")
+			"Modifying the target field of a policy is not allowed. You need to recreate the policy object.")
 		return true, err
 	}
 
-	// Disallow switching the enforcer during modeling.
-	if newEnforcers != oldEnforcers && newVcp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
-		err := fmt.Errorf("disallow switching the enforcer")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+	// Disallow switching the mode of a policy from others to BehaviorModeling.
+	if newVcp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
+		oldAp.Spec.BehaviorModeling.Duration == 0 {
+		err := fmt.Errorf("disallow switching the mode of a policy from others to BehaviorModeling")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"Switching the enforcer during modeling is not allowed. You need to recreate the VarmorClusterPolicy object.")
+			"Switching the mode of a policy from others to BehaviorModeling is not allowed. You need to recreate the policy object.")
 		return true, err
 	}
 
-	// Make sure the EnhanceProtect field has been set when running in the EnhanceProtect mode.
-	if newVcp.Spec.Policy.Mode == varmor.EnhanceProtectMode &&
-		newVcp.Spec.Policy.EnhanceProtect == nil {
-		err := fmt.Errorf("the EnhanceProtect field is not set when running in the EnhanceProtect mode")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
-		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
+	// Disallow switching the mode of a policy from BehaviorModeling to others when behavior modeling is still incomplete.
+	if newVcp.Spec.Policy.Mode != varmor.BehaviorModelingMode &&
+		newVcp.Status.Phase == varmor.VarmorPolicyModeling {
+		err := fmt.Errorf("disallow switching the mode of a policy from BehaviorModeling to others when behavior modeling is still incomplete")
+		logger.Error(err, "update the policy status with forbidden info")
+		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"The EnhanceProtect field should be set when running in the EnhanceProtect mode.")
+			"Switching the mode of a policy from BehaviorModeling to others is not allowed when behavior modeling is still incomplete. You need to recreate the policy object.")
 		return true, err
 	}
 
-	// Disallow modifying the VarmorClusterPolicy that runs in the BehaviorModeling mode and has already been completed.
+	// Disallow modifying the modelingOptions field of a policy that runs in the BehaviorModeling mode and has already been completed.
 	if newVcp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
 		newVcp.Status.Phase == varmor.VarmorPolicyCompleted {
 		if newVcp.Spec.Policy.ModelingOptions == nil ||
 			newVcp.Spec.Policy.ModelingOptions.Duration != oldAp.Spec.BehaviorModeling.Duration {
-			err := fmt.Errorf("disallow modifying the VarmorClusterPolicy that runs in the BehaviorModeling mode and has already been completed")
-			logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+			err := fmt.Errorf("disallow modifying the modelingOptions field of a policy that runs in the BehaviorModeling mode and has already been completed")
+			logger.Error(err, "update the policy status with forbidden info")
 			err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 				"Forbidden",
-				"Modifying the VarmorClusterPolicy that runs in the BehaviorModeling mode and has already been completed is not allowed. You need to recreate the VarmorClusterPolicy object.")
+				"Modifying the modelingOptions field of a policy that runs in the BehaviorModeling mode and has already been completed is not allowed. You need to recreate the policy object.")
 			return true, err
 		} else {
 			err := statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", true, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionTrue, "", "")
@@ -420,14 +390,46 @@ func (c *ClusterPolicyController) ignoreUpdate(newVcp *varmor.VarmorClusterPolic
 		}
 	}
 
-	// Make sure the ModelingOptions field has been set.
+	// Disallow modifing the enforcer field of a policy that runs in the BehaviorModeling mode.
 	if newVcp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
-		newVcp.Spec.Policy.ModelingOptions == nil {
-		err := fmt.Errorf("the ModelingOptions field is not set when running in the BehaviorModeling mode")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		newEnforcers != oldEnforcers {
+		err := fmt.Errorf("disallow modifing the enforcer field of a policy that runs in the BehaviorModeling mode")
+		logger.Error(err, "update the policy status with forbidden info")
+		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
+			"Forbidden",
+			"Modifing the enforcer field of a policy in the BehaviorModeling mode is not allowed. You need to recreate the policy object.")
+		return true, err
+	}
+
+	// Disallow removing the activated AppArmor or Seccomp enforcer.
+	if (newEnforcers&oldEnforcers != oldEnforcers) && (newEnforcers|varmortypes.BPF != oldEnforcers) {
+		err := fmt.Errorf("disallow removing the activated AppArmor or Seccomp enforcer")
+		logger.Error(err, "update the policy status with forbidden info")
+		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
+			"Forbidden",
+			"Modifying a policy to remove the AppArmor or Seccomp enforcer is not allowed. To remove them, you need to recreate the policy object.")
+		return true, err
+	}
+
+	// Make sure the enhanceProtect field has been set when the policy runs in the EnhanceProtect mode.
+	if newVcp.Spec.Policy.Mode == varmor.EnhanceProtectMode &&
+		newVcp.Spec.Policy.EnhanceProtect == nil {
+		err := fmt.Errorf("the enhanceProtect field is not set when the policy runs in the EnhanceProtect mode")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"The ModelingOptions field should be set when running in the BehaviorModeling mode.")
+			"The enhanceProtect field should be set when the policy runs in the EnhanceProtect mode.")
+		return true, err
+	}
+
+	// Make sure the modelingOptions field has been set when the policy runs in BehaviorModeling mode.
+	if newVcp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
+		newVcp.Spec.Policy.ModelingOptions == nil {
+		err := fmt.Errorf("the modelingOptions field is not set when the policy runs in the BehaviorModeling mode")
+		logger.Error(err, "update the policy status with forbidden info")
+		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
+			"Forbidden",
+			"The modelingOptions field should be set when the policy runs in the BehaviorModeling mode.")
 		return true, err
 	}
 

--- a/internal/policy/clusterpolicy_controller.go
+++ b/internal/policy/clusterpolicy_controller.go
@@ -348,7 +348,7 @@ func (c *ClusterPolicyController) ignoreUpdate(newVcp *varmor.VarmorClusterPolic
 		return true, err
 	}
 
-	// Disallow switching mode from others to BehaviorModeling.
+	// Disallow switching the mode from others to BehaviorModeling.
 	if newVcp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
 		oldAp.Spec.BehaviorModeling.Duration == 0 {
 		err := fmt.Errorf("disallow switching spec.policy.mode from others to BehaviorModeling")
@@ -359,14 +359,14 @@ func (c *ClusterPolicyController) ignoreUpdate(newVcp *varmor.VarmorClusterPolic
 		return true, err
 	}
 
-	// Disallow switching mode from BehaviorModeling to others.
+	// Disallow switching the mode from BehaviorModeling to others when behavior modeling is still incomplete.
 	if newVcp.Spec.Policy.Mode != varmor.BehaviorModelingMode &&
-		oldAp.Spec.BehaviorModeling.Duration != 0 {
-		err := fmt.Errorf("disallow switching spec.policy.mode from BehaviorModeling to others")
+		newVcp.Status.Phase == varmor.VarmorPolicyModeling {
+		err := fmt.Errorf("disallow switching spec.policy.mode from BehaviorModeling to others when behavior modeling is still incomplete")
 		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
 		err = statusmanager.UpdateVarmorClusterPolicyStatus(c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"Switching the mode from BehaviorModeling to others is not allowed. You need to recreate the VarmorClusterPolicy object.")
+			"Switching the mode from BehaviorModeling to others is not allowed when behavior modeling is still incomplete. You need to recreate the VarmorClusterPolicy object.")
 		return true, err
 	}
 

--- a/internal/policy/policy_controller.go
+++ b/internal/policy/policy_controller.go
@@ -356,17 +356,6 @@ func (c *PolicyController) ignoreUpdate(newVp *varmor.VarmorPolicy, oldAp *varmo
 		return true, err
 	}
 
-	// Disallow switching the mode of a policy from others to BehaviorModeling.
-	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
-		oldAp.Spec.BehaviorModeling.Duration == 0 {
-		err := fmt.Errorf("disallow switching the mode of a policy from others to BehaviorModeling")
-		logger.Error(err, "update the policy status with forbidden info")
-		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-			"Forbidden",
-			"Switching the mode of a policy from others to BehaviorModeling is not allowed. You need to recreate the policy object.")
-		return true, err
-	}
-
 	// Disallow switching the mode of a policy from BehaviorModeling to others when behavior modeling is still incomplete.
 	if newVp.Spec.Policy.Mode != varmor.BehaviorModelingMode &&
 		newVp.Status.Phase == varmor.VarmorPolicyModeling {
@@ -374,35 +363,19 @@ func (c *PolicyController) ignoreUpdate(newVp *varmor.VarmorPolicy, oldAp *varmo
 		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"Switching the mode of a policy from BehaviorModeling to others is not allowed when behavior modeling is still incomplete. You need to recreate the policy object.")
+			"Switching the mode of a policy from BehaviorModeling to others is not allowed when behavior modeling is still incomplete.")
 		return true, err
 	}
 
-	// Disallow modifying the modelingOptions field of a policy that runs in the BehaviorModeling mode and has already been completed.
+	// Disallow modifying the enforcer field of a policy when behavior modeling is still incomplete.
 	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
-		newVp.Status.Phase == varmor.VarmorPolicyCompleted {
-		if newVp.Spec.Policy.ModelingOptions == nil ||
-			newVp.Spec.Policy.ModelingOptions.Duration != oldAp.Spec.BehaviorModeling.Duration {
-			err := fmt.Errorf("disallow modifying the modelingOptions field of a policy that runs in the BehaviorModeling mode and has already been completed")
-			logger.Error(err, "update the policy status with forbidden info")
-			err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-				"Forbidden",
-				"Modifying the modelingOptions field of a policy that runs in the BehaviorModeling mode and has already been completed is not allowed. You need to recreate the policy object.")
-			return true, err
-		} else {
-			err := statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", true, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionTrue, "", "")
-			return true, err
-		}
-	}
-
-	// Disallow modifing the enforcer field of a policy that runs in the BehaviorModeling mode.
-	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
+		newVp.Status.Phase == varmor.VarmorPolicyModeling &&
 		newEnforcers != oldEnforcers {
-		err := fmt.Errorf("disallow modifing the enforcer field of a policy that runs in the BehaviorModeling mode")
+		err := fmt.Errorf("disallow modifying the enforcer field of a policy when behavior modeling is still incomplete")
 		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"Modifing the enforcer field of a policy in the BehaviorModeling mode is not allowed. You need to recreate the policy object.")
+			"Modifying the enforcer field of a policy is not allowed when behavior modeling is still incomplete.")
 		return true, err
 	}
 
@@ -453,6 +426,8 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 		return err
 	}
 
+	statusKey := newVp.Namespace + "/" + newVp.Name
+
 	// First, reset VarmorPolicy/status
 	logger.Info("1. reset VarmorPolicy/status (updated=true)", "namesapce", newVp.Namespace, "name", newVp.Name)
 	err := statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyPending, varmor.VarmorPolicyUpdated, apicorev1.ConditionTrue, "", "")
@@ -461,9 +436,19 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 		return err
 	}
 
-	// Second, build a new ArmorProfileSpec
-	newApSpec := oldAp.Spec.DeepCopy()
-	newProfile, egressInfo, err := varmorprofile.GenerateProfile(c.kubeClient, c.varmorInterface, newVp.Spec.Policy, oldAp.Name, oldAp.Namespace, false, c.enablePodServiceEgressControl, logger)
+	// Second, create a new ArmorProfileSpec with the updated policy
+	complete := false
+	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
+		if newVp.Spec.Policy.ModelingOptions != nil {
+			createTime := oldAp.CreationTimestamp.Time
+			Duration := time.Duration(newVp.Spec.Policy.ModelingOptions.Duration) * time.Minute
+			if time.Now().After(createTime.Add(Duration)) {
+				complete = true
+			}
+		}
+	}
+
+	newProfile, egressInfo, err := varmorprofile.GenerateProfile(c.kubeClient, c.varmorInterface, newVp.Spec.Policy, oldAp.Name, oldAp.Namespace, complete, c.enablePodServiceEgressControl, logger)
 	if err != nil {
 		logger.Error(err, "GenerateProfile()")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
@@ -475,15 +460,28 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 		}
 		return nil
 	}
+
+	newApSpec := oldAp.Spec.DeepCopy()
 	newApSpec.Profile = *newProfile
 	newApSpec.UpdateExistingWorkloads = newVp.Spec.UpdateExistingWorkloads
 	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
-		newApSpec.BehaviorModeling.Duration = newVp.Spec.Policy.ModelingOptions.Duration
+		// Update the BehaviorModeling duration
+		if newVp.Spec.Policy.ModelingOptions != nil {
+			newApSpec.BehaviorModeling.Duration = newVp.Spec.Policy.ModelingOptions.Duration
+		}
+
+		// Reset the status cache if the BehaviorModeling duration has not expired
+		if !complete {
+			newApSpec.BehaviorModeling.Enable = true
+			logger.Info("reset the status cache", "status key", statusKey)
+			atomic.StoreInt32(&c.statusManager.UpdateDesiredNumber, 1)
+			c.statusManager.ResetCh <- statusKey
+		}
 	}
 
-	// Cache the egress information for the policy which has network egress rules with toPods and toService fields
+	// Third, cache the egress information for the policy which has network egress rules with toPods and toService fields
 	if egressInfo != nil {
-		policyKey := newVp.Namespace + "/" + newVp.Name
+		policyKey := statusKey
 		c.egressCacheMutex.Lock()
 		delete(c.egressCache, policyKey)
 		if len(egressInfo.ToPods) > 0 || len(egressInfo.ToServices) > 0 {
@@ -494,10 +492,8 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 	}
 
 	// Last, do update
-	statusKey := newVp.Namespace + "/" + newVp.Name
-	atomic.StoreInt32(&c.statusManager.UpdateDesiredNumber, 1)
 	if !reflect.DeepEqual(oldAp.Spec, *newApSpec) {
-		// Update object
+		// Update the objects and their statuses if the spec of ArmorProfile has changed
 		logger.Info("2. update the object and its status")
 
 		logger.Info("2.1. reset ArmorProfile/status and ArmorProfileModel/Status", "namespace", oldAp.Namespace, "name", oldAp.Name)
@@ -545,7 +541,7 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 			return err
 		}
 	} else {
-		// Update status
+		// Update the objects' statuses
 		logger.Info("2. update the object' status")
 
 		logger.Info("2.1. update VarmorPolicy/status and ArmorProfile/status", "status key", statusKey)

--- a/internal/policy/policy_controller.go
+++ b/internal/policy/policy_controller.go
@@ -193,44 +193,44 @@ func (c *PolicyController) handleDeleteVarmorPolicy(namespace, name string) erro
 
 func (c *PolicyController) ignoreAdd(vp *varmor.VarmorPolicy, logger logr.Logger) (bool, error) {
 	if vp.Spec.Target.Kind != "Deployment" && vp.Spec.Target.Kind != "StatefulSet" && vp.Spec.Target.Kind != "DaemonSet" && vp.Spec.Target.Kind != "Pod" {
-		err := fmt.Errorf("Target.Kind is not supported")
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
+		err := fmt.Errorf("the target kind is not supported")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, vp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"This kind of target is not supported.")
+			"The target kind is not supported.")
 		return true, err
 	}
 
 	if vp.Spec.Target.Name == "" && vp.Spec.Target.Selector == nil {
-		err := fmt.Errorf("target.Name and target.Selector are empty")
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
+		err := fmt.Errorf("the target name and selector are empty")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, vp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"You should specify the target workload by name or selector.")
+			"You should specify the target workload either by name or selector.")
 		return true, err
 	}
 
 	if vp.Spec.Target.Name != "" && vp.Spec.Target.Selector != nil {
-		err := fmt.Errorf("target.Name and target.Selector are exclusive")
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
+		err := fmt.Errorf("the target name and selector are exclusive")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, vp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"You shouldn't specify the target workload by both both name and selector.")
+			"You shouldn't specify the target workload using both name and selector.")
 		return true, err
 	}
 
 	if vp.Spec.Policy.Mode == varmor.EnhanceProtectMode && vp.Spec.Policy.EnhanceProtect == nil {
-		err := fmt.Errorf("the EnhanceProtect field is not set when running in the EnhanceProtect mode")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		err := fmt.Errorf("the enhanceProtect field is not set when the policy runs in the EnhanceProtect mode")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, vp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"The EnhanceProtect field should be set when running in the EnhanceProtect mode.")
+			"The enhanceProtect field should be set when the policy runs in the EnhanceProtect mode.")
 		return true, err
 	}
 
 	if !c.enableBehaviorModeling && vp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
 		err := fmt.Errorf("the BehaviorModeling feature is not enabled")
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, vp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
 			"The BehaviorModeling feature is not enabled.")
@@ -238,11 +238,11 @@ func (c *PolicyController) ignoreAdd(vp *varmor.VarmorPolicy, logger logr.Logger
 	}
 
 	if c.enableBehaviorModeling && vp.Spec.Policy.Mode == varmor.BehaviorModelingMode && vp.Spec.Policy.ModelingOptions == nil {
-		err := fmt.Errorf("the ModelingOptions field is not set when running in the BehaviorModeling mode")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		err := fmt.Errorf("the modelingOptions field is not set when the policy runs in the BehaviorModeling mode")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, vp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"The ModelingOptions field should be set when running in the BehaviorModeling mode.")
+			"The modelingOptions field should be set when the policy runs in the BehaviorModeling mode.")
 		return true, err
 	}
 
@@ -251,8 +251,8 @@ func (c *PolicyController) ignoreAdd(vp *varmor.VarmorPolicy, logger logr.Logger
 	profileName := varmorprofile.GenerateArmorProfileName(vp.Namespace, vp.Name, false)
 	if len(profileName) > 63 {
 		err := fmt.Errorf("the length of ArmorProfile name is exceed 63. name: %s, length: %d", profileName, len(profileName))
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
-		msg := fmt.Sprintf("The length of VarmorProfile object name is too long, please limit it to %d bytes.", 63-len(varmorprofile.ProfileNameTemplate)+4-len(vp.Namespace))
+		logger.Error(err, "update the policy status with forbidden info")
+		msg := fmt.Sprintf("The length of policy object name is too long, please limit it to %d bytes.", 63-len(varmorprofile.ProfileNameTemplate)+4-len(vp.Namespace))
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, vp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyCreated, apicorev1.ConditionFalse,
 			"Forbidden",
 			msg)
@@ -281,7 +281,7 @@ func (c *PolicyController) handleAddVarmorPolicy(vp *varmor.VarmorPolicy) error 
 			"Error",
 			err.Error())
 		if err != nil {
-			logger.Error(err, "statusmanager.UpdateVarmorClusterPolicyStatus()")
+			logger.Error(err, "statusmanager.UpdateVarmorPolicyStatus()")
 			return err
 		}
 		return nil
@@ -290,7 +290,7 @@ func (c *PolicyController) handleAddVarmorPolicy(vp *varmor.VarmorPolicy) error 
 	logger.Info("update VarmorPolicy/status (created=true)")
 	err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, vp, ap.Spec.Profile.Name, false, varmor.VarmorPolicyPending, varmor.VarmorPolicyCreated, apicorev1.ConditionTrue, "", "")
 	if err != nil {
-		logger.Error(err, "statusmanager.UpdateVarmorClusterPolicyStatus()")
+		logger.Error(err, "statusmanager.UpdateVarmorPolicyStatus()")
 		return err
 	}
 
@@ -343,81 +343,51 @@ func (c *PolicyController) handleAddVarmorPolicy(vp *varmor.VarmorPolicy) error 
 }
 
 func (c *PolicyController) ignoreUpdate(newVp *varmor.VarmorPolicy, oldAp *varmor.ArmorProfile, logger logr.Logger) (bool, error) {
-	// Disallow modifying the target of VarmorPolicy.
-	if !reflect.DeepEqual(newVp.Spec.Target, oldAp.Spec.Target) {
-		err := fmt.Errorf("disallow modifying spec.target")
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
-		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-			"Forbidden",
-			"Modifying the target of VarmorPolicy is not allowed. You need to recreate the VarmorPolicy object.")
-		return true, err
-	}
-
-	// Disallow switching the mode from others to BehaviorModeling.
-	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
-		oldAp.Spec.BehaviorModeling.Duration == 0 {
-		err := fmt.Errorf("disallow switching spec.policy.mode from others to BehaviorModeling")
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
-		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-			"Forbidden",
-			"Switching the mode from others to BehaviorModeling is not allowed. You need to recreate the VarmorPolicy object.")
-		return true, err
-	}
-
-	// Disallow switching the mode from BehaviorModeling to others when behavior modeling is still incomplete.
-	if newVp.Spec.Policy.Mode != varmor.BehaviorModelingMode &&
-		newVp.Status.Phase == varmor.VarmorPolicyModeling {
-		err := fmt.Errorf("disallow switching spec.policy.mode from BehaviorModeling to others when behavior modeling is still incomplete")
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
-		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-			"Forbidden",
-			"Switching the mode from BehaviorModeling to others is not allowed when behavior modeling is still incomplete. You need to recreate the VarmorPolicy object.")
-		return true, err
-	}
-
-	// Disallow shutting down the activated AppArmor or Seccomp enforcer.
 	newEnforcers := varmortypes.GetEnforcerType(newVp.Spec.Policy.Enforcer)
 	oldEnforcers := varmortypes.GetEnforcerType(oldAp.Spec.Profile.Enforcer)
-	if (newEnforcers&oldEnforcers != oldEnforcers) && (newEnforcers|varmortypes.BPF != oldEnforcers) {
-		err := fmt.Errorf("disallow shutting down the activated AppArmor or Seccomp enforcer")
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
+
+	// Disallow modifying the target field of a policy.
+	if !reflect.DeepEqual(newVp.Spec.Target, oldAp.Spec.Target) {
+		err := fmt.Errorf("disallow modifying the target field of a policy")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"Modifying a policy to remove the AppArmor or Seccomp enforcer is not allowed. To remove them, you need to recreate the VarmorPolicy object.")
+			"Modifying the target field of a policy is not allowed. You need to recreate the policy object.")
 		return true, err
 	}
 
-	// Disallow switching the enforcer during modeling.
-	if newEnforcers != oldEnforcers && newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
-		err := fmt.Errorf("disallow switching the enforcer")
-		logger.Error(err, "update VarmorPolicy/status with forbidden info")
+	// Disallow switching the mode of a policy from others to BehaviorModeling.
+	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
+		oldAp.Spec.BehaviorModeling.Duration == 0 {
+		err := fmt.Errorf("disallow switching the mode of a policy from others to BehaviorModeling")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"Switching the enforcer during modeling is not allowed. You need to recreate the VarmorPolicy object.")
+			"Switching the mode of a policy from others to BehaviorModeling is not allowed. You need to recreate the policy object.")
 		return true, err
 	}
 
-	// Make sure the EnhanceProtect field has been set when running in the EnhanceProtect mode.
-	if newVp.Spec.Policy.Mode == varmor.EnhanceProtectMode &&
-		newVp.Spec.Policy.EnhanceProtect == nil {
-		err := fmt.Errorf("the EnhanceProtect field is not set when running in the EnhanceProtect mode")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
-		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
+	// Disallow switching the mode of a policy from BehaviorModeling to others when behavior modeling is still incomplete.
+	if newVp.Spec.Policy.Mode != varmor.BehaviorModelingMode &&
+		newVp.Status.Phase == varmor.VarmorPolicyModeling {
+		err := fmt.Errorf("disallow switching the mode of a policy from BehaviorModeling to others when behavior modeling is still incomplete")
+		logger.Error(err, "update the policy status with forbidden info")
+		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"The EnhanceProtect field should be set when running in the EnhanceProtect mode.")
+			"Switching the mode of a policy from BehaviorModeling to others is not allowed when behavior modeling is still incomplete. You need to recreate the policy object.")
 		return true, err
 	}
 
-	// Disallow modifying the VarmorPolicy that runs in the BehaviorModeling mode and has already been completed.
+	// Disallow modifying the modelingOptions field of a policy that runs in the BehaviorModeling mode and has already been completed.
 	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
 		newVp.Status.Phase == varmor.VarmorPolicyCompleted {
 		if newVp.Spec.Policy.ModelingOptions == nil ||
 			newVp.Spec.Policy.ModelingOptions.Duration != oldAp.Spec.BehaviorModeling.Duration {
-			err := fmt.Errorf("disallow modifying the VarmorPolicy that runs in the BehaviorModeling mode and has already been completed")
-			logger.Error(err, "update VarmorPolicy/status with forbidden info")
+			err := fmt.Errorf("disallow modifying the modelingOptions field of a policy that runs in the BehaviorModeling mode and has already been completed")
+			logger.Error(err, "update the policy status with forbidden info")
 			err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 				"Forbidden",
-				"Modifying the VarmorPolicy that runs in the BehaviorModeling mode and has already been completed is not allowed. You need to recreate the VarmorPolicy object.")
+				"Modifying the modelingOptions field of a policy that runs in the BehaviorModeling mode and has already been completed is not allowed. You need to recreate the policy object.")
 			return true, err
 		} else {
 			err := statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", true, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionTrue, "", "")
@@ -425,14 +395,46 @@ func (c *PolicyController) ignoreUpdate(newVp *varmor.VarmorPolicy, oldAp *varmo
 		}
 	}
 
-	// Make sure the ModelingOptions field has been set when running with BehaviorModeling mode.
+	// Disallow modifing the enforcer field of a policy that runs in the BehaviorModeling mode.
 	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
-		newVp.Spec.Policy.ModelingOptions == nil {
-		err := fmt.Errorf("the ModelingOptions field is not set when running in the BehaviorModeling mode")
-		logger.Error(err, "update VarmorClusterPolicy/status with forbidden info")
+		newEnforcers != oldEnforcers {
+		err := fmt.Errorf("disallow modifing the enforcer field of a policy that runs in the BehaviorModeling mode")
+		logger.Error(err, "update the policy status with forbidden info")
+		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
+			"Forbidden",
+			"Modifing the enforcer field of a policy in the BehaviorModeling mode is not allowed. You need to recreate the policy object.")
+		return true, err
+	}
+
+	// Disallow removing the activated AppArmor or Seccomp enforcer.
+	if (newEnforcers&oldEnforcers != oldEnforcers) && (newEnforcers|varmortypes.BPF != oldEnforcers) {
+		err := fmt.Errorf("disallow removing the activated AppArmor or Seccomp enforcer")
+		logger.Error(err, "update the policy status with forbidden info")
+		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
+			"Forbidden",
+			"Modifying a policy to remove the AppArmor or Seccomp enforcer is not allowed. To remove them, you need to recreate the policy object.")
+		return true, err
+	}
+
+	// Make sure the enhanceProtect field has been set when the policy runs in the EnhanceProtect mode.
+	if newVp.Spec.Policy.Mode == varmor.EnhanceProtectMode &&
+		newVp.Spec.Policy.EnhanceProtect == nil {
+		err := fmt.Errorf("the enhanceProtect field is not set when the policy runs in the EnhanceProtect mode")
+		logger.Error(err, "update the policy status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"The ModelingOptions field should be set when running in the BehaviorModeling mode.")
+			"The enhanceProtect field should be set when the policy runs in the EnhanceProtect mode.")
+		return true, err
+	}
+
+	// Make sure the modelingOptions field has been set when the policy running in BehaviorModeling mode.
+	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
+		newVp.Spec.Policy.ModelingOptions == nil {
+		err := fmt.Errorf("the modelingOptions field is not set when the policy runs in the BehaviorModeling mode")
+		logger.Error(err, "update the policy status with forbidden info")
+		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
+			"Forbidden",
+			"The modelingOptions field should be set when the policy runs in the BehaviorModeling mode.")
 		return true, err
 	}
 
@@ -455,7 +457,7 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 	logger.Info("1. reset VarmorPolicy/status (updated=true)", "namesapce", newVp.Namespace, "name", newVp.Name)
 	err := statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyPending, varmor.VarmorPolicyUpdated, apicorev1.ConditionTrue, "", "")
 	if err != nil {
-		logger.Error(err, "statusmanager.UpdateVarmorClusterPolicyStatus()")
+		logger.Error(err, "statusmanager.UpdateVarmorPolicyStatus()")
 		return err
 	}
 
@@ -468,7 +470,7 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 			"Error",
 			err.Error())
 		if err != nil {
-			logger.Error(err, "statusmanager.UpdateVarmorClusterPolicyStatus()")
+			logger.Error(err, "statusmanager.UpdateVarmorPolicyStatus()")
 			return err
 		}
 		return nil

--- a/internal/policy/policy_controller.go
+++ b/internal/policy/policy_controller.go
@@ -353,7 +353,7 @@ func (c *PolicyController) ignoreUpdate(newVp *varmor.VarmorPolicy, oldAp *varmo
 		return true, err
 	}
 
-	// Disallow switching mode from others to BehaviorModeling.
+	// Disallow switching the mode from others to BehaviorModeling.
 	if newVp.Spec.Policy.Mode == varmor.BehaviorModelingMode &&
 		oldAp.Spec.BehaviorModeling.Duration == 0 {
 		err := fmt.Errorf("disallow switching spec.policy.mode from others to BehaviorModeling")
@@ -364,14 +364,14 @@ func (c *PolicyController) ignoreUpdate(newVp *varmor.VarmorPolicy, oldAp *varmo
 		return true, err
 	}
 
-	// Disallow switching mode from BehaviorModeling to others.
+	// Disallow switching the mode from BehaviorModeling to others when behavior modeling is still incomplete.
 	if newVp.Spec.Policy.Mode != varmor.BehaviorModelingMode &&
-		oldAp.Spec.BehaviorModeling.Duration != 0 {
-		err := fmt.Errorf("disallow switching spec.policy.mode from BehaviorModeling to others")
+		newVp.Status.Phase == varmor.VarmorPolicyModeling {
+		err := fmt.Errorf("disallow switching spec.policy.mode from BehaviorModeling to others when behavior modeling is still incomplete")
 		logger.Error(err, "update VarmorPolicy/status with forbidden info")
 		err = statusmanager.UpdateVarmorPolicyStatus(c.varmorInterface, newVp, "", false, varmor.VarmorPolicyUnchanged, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
 			"Forbidden",
-			"Switching the mode from BehaviorModeling to others is not allowed. You need to recreate the VarmorPolicy object.")
+			"Switching the mode from BehaviorModeling to others is not allowed when behavior modeling is still incomplete. You need to recreate the VarmorPolicy object.")
 		return true, err
 	}
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -313,8 +313,8 @@ func NewArmorProfile(
 		ap.Spec.UpdateExistingWorkloads = vcp.Spec.UpdateExistingWorkloads
 
 		if vcp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
-			if vcp.Spec.Policy.ModelingOptions.Duration == 0 {
-				return nil, nil, fmt.Errorf("invalid parameter: .Spec.Policy.ModelingOptions.Duration == 0")
+			if vcp.Spec.Policy.ModelingOptions == nil || vcp.Spec.Policy.ModelingOptions.Duration == 0 {
+				return nil, nil, fmt.Errorf("invalid parameter: the Spec.Policy.ModelingOptions.Duration field cannot be empty or 0")
 			}
 			ap.Spec.BehaviorModeling.Enable = true
 			ap.Spec.BehaviorModeling.Duration = vcp.Spec.Policy.ModelingOptions.Duration
@@ -345,8 +345,8 @@ func NewArmorProfile(
 		ap.Spec.UpdateExistingWorkloads = vp.Spec.UpdateExistingWorkloads
 
 		if vp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
-			if vp.Spec.Policy.ModelingOptions.Duration == 0 {
-				return nil, nil, fmt.Errorf("invalid parameter: .Spec.Policy.ModelingOptions.Duration == 0")
+			if vp.Spec.Policy.ModelingOptions == nil || vp.Spec.Policy.ModelingOptions.Duration == 0 {
+				return nil, nil, fmt.Errorf("invalid parameter: the Spec.Policy.ModelingOptions.Duration field cannot be empty or 0")
 			}
 			ap.Spec.BehaviorModeling.Enable = true
 			ap.Spec.BehaviorModeling.Duration = vp.Spec.Policy.ModelingOptions.Duration


### PR DESCRIPTION
# What this PR does
Enables dynamic switching of policy modes between `BehaviorModeling` and `DefenseInDepth` (or other modes) without recreating policies, enhancing user experience and operational flexibility.  

# Main Code Changes
- Allows switching from `BehaviorModeling` to other modes (e.g., `DefenseInDepth`) once behavior modeling is complete  
- Supports switching from other modes back to `BehaviorModeling` with automatic restart of the modeling process  
- Implements reconstruction of `modelingStatuses` cache based on `ArmorProfile` when the Manager leader initializes  
- Refactors policy validation logic for clearer mode transition checks  

# Benefits
- Eliminates the need to delete/recreate policies for mode changes, reducing operational overhead  
- Improves workflow continuity when transitioning from modeling to enforcement  
- Enhances system robustness with consistent state management during leader failover  
- Simplifies policy lifecycle management for security administrators  

# Related Issue
- Fixes #236   

# Notes
- Mode switching from `BehaviorModeling` to other modes requires modeling to reach "completed" status
- Switching back to `BehaviorModeling` and restarting the modeling, you need to update the modeling duration and restart the target workloads