### PR TITLE
Update Seccomp profile to AlwaysAllow post-behavior modeling

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -178,8 +178,14 @@ func GenerateProfile(
 		}
 		// Seccomp
 		if (e & varmortypes.Seccomp) != 0 {
-			profile.Mode = varmor.ProfileModeComplain
-			profile.SeccompContent = seccompprofile.GenerateBehaviorModelingProfile()
+			if complete {
+				// Create profile based on the AlwaysAllow template after the behvior modeling was completed.
+				profile.Mode = varmor.ProfileModeEnforce
+				profile.SeccompContent = seccompprofile.GenerateAlwaysAllowProfile()
+			} else {
+				profile.Mode = varmor.ProfileModeComplain
+				profile.SeccompContent = seccompprofile.GenerateBehaviorModelingProfile()
+			}
 		}
 
 	case varmor.DefenseInDepthMode:


### PR DESCRIPTION
# What this PR does 
Adjusts seccomp profile behavior to switch to `AlwaysAllow` mode once behavior modeling is complete, aligning with AppArmor enforcer behavior. Newly created workloads will no longer generate audit events, while existing workloads require a restart to apply the updated profile.  

# Main Code Changes
Added conditional logic to seccomp profile generation:  
- When behavior modeling is complete (`complete = true`), uses `ProfileModeEnforce` and `GenerateAlwaysAllowProfile()`  
- When modeling is in progress, retains `ProfileModeComplain` and `GenerateBehaviorModelingProfile()`  

# Benefits
- Reduces unnecessary audit events for new workloads after modeling completion  
- Standardizes behavior between seccomp and AppArmor enforcers   

# Notes
- Existing workloads will continue using the old seccomp profile until restarted  
- No impact on modeling accuracy, audit events are only disabled for new workloads post-completion  