### PR TITLE
Add Persistent Volume Support for LocalDisk ArmorProfileModel Data

### DIFF
--- a/manifests/varmor/templates/deployments/manager.yaml
+++ b/manifests/varmor/templates/deployments/manager.yaml
@@ -127,9 +127,15 @@ spec:
           {{- toYaml .Values.manager.resources | nindent 10 }}
       {{- if .Values.behaviorModeling.enabled }}
       volumes:
-        {{- with .Values.manager.behaviorModeling.volumes }}
-          {{- toYaml . | nindent 6 }}
-        {{- end }}
+      {{- if .Values.manager.behaviorModeling.usePersistentVolume }} 
+      - persistentVolumeClaim:
+          claimName: {{ .Values.manager.behaviorModeling.persistentVolume.claimName }}
+        name: {{ .Values.manager.behaviorModeling.persistentVolume.name }}
+      {{- else }}
+      - emptyDir:
+          sizeLimit: {{ .Values.manager.behaviorModeling.emptyDirVolume.sizeLimit }}
+        name: {{ .Values.manager.behaviorModeling.emptyDirVolume.name }}
+      {{- end }}
       {{- end }}
       {{- with .Values.manager.nodeSelector }}
       nodeSelector:

--- a/manifests/varmor/values.yaml
+++ b/manifests/varmor/values.yaml
@@ -107,16 +107,22 @@ manager:
     - --enableBpfEnforcer
 
   behaviorModeling:
+    # Set this to true to use a persistent volume for storing LocalDisk-type ArmorProfileModel objects.
+    # Different instances of the manager will share the same data to ensure compatibility of LocalDisk-type ArmorProfileModel objects.
+    # Note: You must first create a valid PVC named varmor-manager-apmdata-pvc in the same namespace as the manager pod.
+    usePersistentVolume: false
     args:
     - --enableBehaviorModeling
     # The volume saves the ArmorProfileModel objects in the manager pod
     volumeMounts:
     - mountPath: /var/log/varmor/apmdata
-      name: data-volume
-    volumes:
-    - emptyDir:
-        sizeLimit: 500Mi
-      name: data-volume
+      name: apmdata
+    emptyDirVolume:
+      sizeLimit: 500Mi
+      name: apmdata
+    persistentVolume:
+      claimName: varmor-manager-apmdata-pvc
+      name: apmdata
 
   podServiceEgressControl:
     args:
@@ -256,11 +262,11 @@ agent:
     # The volume caches the audit data in the agent pod during modeling
     volumeMounts:
     - mountPath: /var/log/varmor/auditdata
-      name: data-volume
+      name: auditdata
     volumes:
     - emptyDir:
         sizeLimit: 500Mi
-      name: data-volume
+      name: auditdata
     resources:
       limits:
         cpu: 2


### PR DESCRIPTION
# What this PR does
Resolves data accessibility issues in multi-replica manager deployments by adding persistent volume (PV) support for LocalDisk-type `ArmorProfileModel` objects, enabling data sharing across manager instances.  

# Key Features Added 
- Introduced `behaviorModeling.usePersistentVolume` Helm value to toggle PV usage for LocalDisk-type `ArmorProfileModel` data  
- Added Helm template configurations for persistent volume integration:  
  - Defined `persistentVolume` settings with configurable PVC claim name (`varmor-manager-apmdata-pvc`)  
  - Maintained existing `emptyDir` volume as default storage option
  - Updated volume mounts to use shared storage path `/var/log/varmor/apmdata` across instances  

# Benefits
- Enables data consistency across manager replicas in multi-instance deployments  
- Prevents data loss during leader re-election by centralizing LocalDisk-type `ArmorProfileModel` data  
- Improves reliability of `ArmorProfileModel` import/export operations across manager restarts  
- Provides flexibility to scale storage beyond node-local `emptyDir` limits  

# Notes
- Requires manual creation of a PVC named `varmor-manager-apmdata-pvc` in the manager namespace before enabling `usePersistentVolume`  
- `emptyDir` remains default with a 500Mi size limit for lightweight deployments  