### PR TITLE
Record the Seccomp event with `AUDIT|ALLOWED` action

### DIFF
--- a/pkg/auditor/audit.go
+++ b/pkg/auditor/audit.go
@@ -191,9 +191,10 @@ func (auditor *Auditor) processAuditEvent(event string) {
 		}
 
 		if len(auditor.auditEventChs) == 0 {
-			// Only record the allowed event when there is no policy in the BehaviorModeling mode.
+			// Only record the event when there is no policy in the BehaviorModeling mode.
 			// This can reduce the noise in the violation log.
-			// Therefore, the audit events of the DefenseInDepth mode will only be recorded when no policy is modeling.
+			// The events of the policy in the DefenseInDepth or EnhanceProtect mode will
+			// be recorded when no policy is being modeling.
 			auditor.violationLogger.Debug().
 				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
@@ -207,7 +208,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Uint32("mntNsID", mntNsID).
 				Uint64("eventTimestamp", e.Epoch).
 				Str("enforcer", "Seccomp").
-				Str("action", "ALLOWED").
+				Str("action", "AUDIT|ALLOWED").
 				Str("profileName", profileName).
 				Interface("event", e).Msg("violation event")
 		} else {


### PR DESCRIPTION
# What this PR does
Adjusts the `action` field in Seccomp audit events to match the behavior of AppArmor and BPF enforcers.

# Main Code Changes
Updated Seccomp audit event `action` field from static "ALLOWED" to "AUDIT|ALLOWED":  
- "AUDIT":  Policies run in `EnhanceProtect` mode with `allowViolations=true` & `auditViolations=true`
- "ALLOWED": Policies run in `DefenseInDepth` mode `allowViolations=true`

# Benefits
Reduces operational confusion when cross-referencing events from different enforcers  