### PR TITLE
Unify Violation Logs to Warn Level for Consistent Logging

### DIFF
--- a/pkg/auditor/audit.go
+++ b/pkg/auditor/audit.go
@@ -99,7 +99,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Str("profileName", profileName).
 				Interface("event", e).Msg("violation event")
 		case AuditAction:
-			auditor.violationLogger.Debug().
+			auditor.violationLogger.Warn().
 				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
 				Str("podUID", info.PodUID).
@@ -122,7 +122,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 			} else {
 				// Only record the allowed event when the policy is in the DefenseInDepth mode.
 				// This can reduce the noise in the violation log.
-				auditor.violationLogger.Debug().
+				auditor.violationLogger.Warn().
 					Interface("metadata", auditor.auditEventMetadata).
 					Str("nodeName", auditor.nodeName).
 					Str("podUID", info.PodUID).
@@ -195,7 +195,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 			// This can reduce the noise in the violation log.
 			// The events of the policy in the DefenseInDepth or EnhanceProtect mode will
 			// be recorded when no policy is being modeling.
-			auditor.violationLogger.Debug().
+			auditor.violationLogger.Warn().
 				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
 				Str("podUID", info.PodUID).

--- a/pkg/auditor/bpf.go
+++ b/pkg/auditor/bpf.go
@@ -349,7 +349,7 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 
 		case bpfenforcer.AuditAction:
 			// Write the violation event into the log file
-			auditor.violationLogger.Debug().
+			auditor.violationLogger.Warn().
 				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
 				Str("podUID", auditor.containerCache[eventHeader.MntNs].PodUID).


### PR DESCRIPTION
# What this PR does
Standardizes all violation logs (regardless of action type) to use `warn` log level, ensuring consistent logging behavior and preventing log loss caused by inappropriate `verbosity level` configurations.  

# Main Code Changes
Updated all violation log outputs (covering AppArmor/Seccomp/BPF enforcers, various action types like `ALLOWED`/`AUDIT`/`DENIED`) to use `warn` level.  