### PR TITLE
Adjust AppArmor Profile Sub-Profile Rule Indentation for Better Readability

### DIFF
--- a/internal/profile/apparmor/rules.go
+++ b/internal/profile/apparmor/rules.go
@@ -486,7 +486,7 @@ func generateEnhanceProtectRulesForTargets(enhanceProtect *varmor.EnhanceProtect
 
 		targetsRix := ""
 		for _, target := range aarule.Targets {
-			targetsRix += fmt.Sprintf("%s rix,\n", target)
+			targetsRix += fmt.Sprintf("  %s rix,\n", target)
 		}
 
 		// Generate the final child profile for targets

--- a/internal/profile/apparmor/template.go
+++ b/internal/profile/apparmor/template.go
@@ -183,7 +183,8 @@ ptrace (trace,read) peer=%s,
 
 %s
 profile %s flags=(attach_disconnected,mediate_deleted) {
-  %s
+
+%s
   #include <abstractions/base>
 
   network,


### PR DESCRIPTION
# What this PR does
Standardizes the indentation format of sub-profile rules in AppArmor profiles generated by vArmor, improving code readability and maintainability without modifying any functional logic or security behavior.  
