### PR TITLE
 Adjust AppArmor Profile Sub-Profile Rule Indentation for Better Readability

### DIFF
--- a/internal/profile/apparmor/rules.go
+++ b/internal/profile/apparmor/rules.go
@@ -564,7 +564,7 @@ func generateDefenseInDepthCustomRulesForTargets(appArmorRawRules []varmor.AppAr
 
 		targetsRix := ""
 		for _, target := range aarule.Targets {
-			targetsRix += fmt.Sprintf("%s rix,\n", target)
+			targetsRix += fmt.Sprintf("  %s rix,\n", target)
 		}
 
 		// Generate the final child profile for targets

--- a/internal/profile/apparmor/template.go
+++ b/internal/profile/apparmor/template.go
@@ -44,7 +44,8 @@ const alwaysAllowChildTemplate = `
 
 %s
 profile %s flags=(attach_disconnected,mediate_deleted) {
-  %s
+
+%s
   #include <abstractions/base>
 
   file,
@@ -263,7 +264,8 @@ ptrace (trace,read) peer=%s,
 
 %s
 profile %s flags=(attach_disconnected,mediate_deleted) {
-  %s
+
+%s
   #include <abstractions/base>
 
   # processes with child profile may receive signals from processes with parent profile.


### PR DESCRIPTION
# What this PR does

Standardizes the indentation format of sub-profile rules in AppArmor profiles generated by vArmor, improving code readability and maintainability without modifying any functional logic or security behavior.
