### PR TITLE
Remove Forced zerolog UnixMicro Time Format Configuration

### DIFF
--- a/cmd/varmor/main.go
+++ b/cmd/varmor/main.go
@@ -97,7 +97,6 @@ func setLogger() {
 	var logrLogger logr.Logger
 	switch logFormat {
 	case "json":
-		zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMicro
 		zerologger := zerolog.New(os.Stdout).With().Timestamp().Caller().Logger()
 		zerologr.SetMaxV(verbosity)
 		logrLogger = zerologr.New(&zerologger)


### PR DESCRIPTION
# What this PR does
Removes the `zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMicro` configuration from the JSON log format setup, restoring zerolog’s default time field behavior for vArmor’s JSON-formatted logs.  
