### PR TITLE
Add Pre-Delete Hook to Cleanup Policy Resources

### DIFF
--- a/cmd/varmor/predelete.go
+++ b/cmd/varmor/predelete.go
@@ -1,0 +1,93 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"time"
+
+	varmorclient "github.com/bytedance/vArmor/pkg/client/clientset/versioned"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func preDeleteHook(kubeClient *kubernetes.Clientset, varmorClient *varmorclient.Clientset, logger logr.Logger) error {
+	// Delete all vArmor resources
+	logger = logger.WithName("PRE-DELETE")
+	logger.Info("Try to delete all vArmor resources")
+
+	var err error
+	// Delete all VarmorClusterPolicy objects
+	e := deleteVarmorClusterPolicies(varmorClient, logger)
+	if e != nil {
+		err = e
+	}
+
+	// Delete all VarmorPolicy objects in all namespaces
+	e = deleteVarmorPolicies(kubeClient, varmorClient, logger)
+	if e != nil {
+		err = e
+	}
+
+	// Wait for all armorprofile objects to be deleted
+	time.Sleep(5 * time.Second)
+	logger.Info("done")
+
+	return err
+}
+
+func deleteVarmorClusterPolicies(varmorClient *varmorclient.Clientset, logger logr.Logger) error {
+	// Use DeleteCollection to delete all VarmorClusterPolicy objects
+	err := varmorClient.CrdV1beta1().VarmorClusterPolicies().DeleteCollection(
+		context.Background(),
+		v1.DeleteOptions{},
+		v1.ListOptions{},
+	)
+	if err != nil {
+		logger.Error(err, "Failed to delete VarmorClusterPolicy objects")
+	} else {
+		logger.Info("Successfully deleted all VarmorClusterPolicy objects")
+	}
+
+	return err
+}
+
+func deleteVarmorPolicies(kubeClient *kubernetes.Clientset, varmorClient *varmorclient.Clientset, logger logr.Logger) error {
+	// Get all namespaces
+	namespaces, err := kubeClient.CoreV1().Namespaces().List(context.Background(), v1.ListOptions{})
+	if err != nil {
+		logger.Error(err, "Failed to list namespaces")
+		return err
+	}
+
+	// Delete VarmorPolicy objects in each namespace
+	for _, namespace := range namespaces.Items {
+		namespaceLogger := logger.WithValues("namespace", namespace.Name)
+
+		e := varmorClient.CrdV1beta1().VarmorPolicies(namespace.Name).DeleteCollection(
+			context.Background(),
+			v1.DeleteOptions{},
+			v1.ListOptions{},
+		)
+		if e != nil {
+			namespaceLogger.Error(err, "Failed to delete VarmorPolicy objects")
+			err = e
+		} else {
+			namespaceLogger.Info("Successfully deleted VarmorPolicy objects")
+		}
+	}
+	return err
+}

--- a/config/k8s-resource/rbac/manager-clusterrole.yaml
+++ b/config/k8s-resource/rbac/manager-clusterrole.yaml
@@ -51,6 +51,7 @@ rules:
   - get
   - list
   - watch
+  - deletecollection
 - apiGroups:
   - crd.varmor.org
   resources:
@@ -67,6 +68,7 @@ rules:
   - get
   - list
   - watch
+  - deletecollection
 - apiGroups:
   - crd.varmor.org
   resources:

--- a/manifests/varmor/templates/jobs/predelete.yaml
+++ b/manifests/varmor/templates/jobs/predelete.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-pre-delete-cleanup
+  namespace: {{ include "varmor.namespace" . }}
+  annotations:
+    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+spec:
+  activeDeadlineSeconds: 60
+  backoffLimit: 1
+  template:
+    spec:
+      {{- if .Values.image.password }}
+      imagePullSecrets:
+        {{- with .Values.imagePullSecrets }}
+          {{- toYaml . | nindent 6 }}
+        {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "varmor.manager.serviceAccountName" . }}
+      containers:
+      - name: pre-delete-cleanup-container
+        {{- if .Values.image.registry }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.namespace }}/{{ .Values.manager.image.name }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}"
+        {{- else }}
+        image: "{{ .Values.publicConfig.registry }}/{{ .Values.manager.image.name }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}"
+        {{- end }}
+        imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
+        command: ["/varmor/vArmor"]
+        args: ["--preDelete"]
+        resources:
+          limits:
+            cpu: "100m"
+            memory: "128Mi"
+          requests:
+            cpu: "50m"
+            memory: "64Mi"
+      restartPolicy: Never

--- a/manifests/varmor/templates/rbac/manager-clusterrole.yaml
+++ b/manifests/varmor/templates/rbac/manager-clusterrole.yaml
@@ -45,6 +45,7 @@ rules:
   - get
   - list
   - watch
+  - deletecollection
 - apiGroups:
   - crd.varmor.org
   resources:
@@ -61,6 +62,7 @@ rules:
   - get
   - list
   - watch
+  - deletecollection
 - apiGroups:
   - crd.varmor.org
   resources:


### PR DESCRIPTION
# What this PR does
This PR implements the first-stage optimization for vArmor's Helm chart: it retains CRD files in the templates directory to facilitate rapid iteration and CRD updates during the rapid iteration phase, and adds a pre-delete hook to automatically clean up VarmorPolicy and VarmorClusterPolicy custom resources when uninstalling the vArmor Helm release. This addresses the resource residual issue caused by CRD deletion and finalizers during uninstallation, while maintaining the flexibility of rapid CRD iteration.

# Key Features Added
* Add --preDelete command-line flag & native cleanup logic
  * Introduce a boolean --preDelete flag to trigger the pre-delete cleanup workflow in the vArmor binary
  * Implement preDeleteHook() function that uses the official varmor client to delete all policies
  * Aggregate errors from cluster/namespaced policy deletion and return a single error
* Helm pre-delete hook Job configuration
  * Create templates/jobs/predelete.yaml defining a Job triggered by the pre-delete Helm hook
* RBAC permission enhancement
  * Update manager-clusterrole.yaml to add the deletecollection verb for varmorpolicies and varmorclusterpolicies

# Benefits
* Resolve uninstall residual issues
Automatically deletes policy resources before CRD removal, preventing ArmorProfile resources from getting stuck in Terminating state (and subsequent CRD registration failures during reinstallation).
* Native & reliable cleanup
Uses the official vArmor client library for policy deletion–eliminates external image dependencies and leverages Kubernetes native DeleteCollection API for efficient bulk deletion.
* Preserve rapid iteration
Retaining CRDs in the templates directory maintains support for helm upgrade-driven CRD updates (critical for early-stage feature iteration).
