### PR TITLE
fix: Goroutine leak caused by async metrics update in large-scale clusters

### DIFF
--- a/internal/status/apis/v1/status.go
+++ b/internal/status/apis/v1/status.go
@@ -58,7 +58,7 @@ func (m *StatusManager) Status(c *gin.Context) {
 	m.statusQueue.Add(profileStatus)
 
 	if m.metricsModule.Enabled {
-		go m.handleProfileStatusUpdate(profileStatus)
+		m.handleProfileStatusUpdate(profileStatus)
 	}
 
 	c.Status(http.StatusOK)


### PR DESCRIPTION
# What this PR does
Fixes the goroutine leak in the Status() HTTP handler by changing the metrics update from asynchronous to synchronous.

# Related Issue
#289 