### PR TITLE
refactor: Split PodServiceEgressControl feature gate into ServiceEgressControl and PodEgressControl

### DIFF
--- a/.github/workflows/ci-e2e-test.yml
+++ b/.github/workflows/ci-e2e-test.yml
@@ -191,6 +191,7 @@ jobs:
               --namespace varmor --create-namespace \
               --set image.registry="elkeid-ap-southeast-1.cr.volces.com" \
               --set bpfLsmEnforcer.enabled=false \
+              --set podEgressControl.enabled=true \
               --set image.namespace="varmor-test" \
               --set manager.image.pullPolicy="Never" \
               --set agent.image.pullPolicy="Never" \

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -108,14 +108,14 @@ vArmor allows users to decide whether to perform a rolling restart on all target
 --set restartExistWorkloads.enabled=false
 ```
 
-#### Disable Pod and Service Egress Control
-The feature extends network access control to restrict container access to specific Pods and Services. You can use the following option to disable it. Default: enabled.
+#### Enable Pod Egress Control
+The feature extends network access control to restrict container access to specific Pod IPs. You can use the following option to enable it. Default: disabled.
 
 ```bash
---set podServiceEgressControl.enabled=false
+--set podEgressControl.enabled=true
 ```
 
-The feature is currently only supported by the BPF enforcer and requires Kubernetes v1.21 or higher.
+The feature is currently only supported by the BPF enforcer. When enabling this feature, you may need to allocate more memory to the manager to watch pods. It is not recommended to enable this feature in large-scale clusters (such as those with 10k+ nodes).
 
 #### Run Agent in HostNetwork Mode
 The agent runs in its own network namespace and exposes the readinessProbe on port `9580` by default. If you want to run it in the host's network namespace, you can use following options.

--- a/docs/getting_started/installation.zh_CN.md
+++ b/docs/getting_started/installation.zh_CN.md
@@ -108,14 +108,14 @@ vArmor 只会对包含此 label 的 Workloads 开启沙箱防护。你可以使�
 --set restartExistWorkloads.enabled=false
 ```
 
-#### 关闭 Pod 和 Service 出口控制
-此功能扩展了网络访问控制，以限制容器对特定 Pod 和 Service 的访问。您可以使用下面的选项关闭它。默认值：开启。
+#### 开启 Pod 出口控制
+此功能扩展了网络访问控制，以限制容器对特定 Pod IPs 的访问。您可以使用下面的选项关闭它。默认值：开启。
 
 ```bash
---set podServiceEgressControl.enabled=false
+--set podEgressControl.enabled=false
 ```
 
-当前仅 BPF enforcer 支持此功能，并且需要 Kubernetes v1.21 及以上版本。
+当前仅 BPF enforcer 支持此功能。开启此功能时，您可能需要为 manager 设置更多内存，以便其 watch pods 变化。不建议在大规模集群（如 10k+ 节点）中启用此功能。
 
 #### 在宿主机网络命名空间中运行 Agent
 vArmor 的 Agent 默认运行在独立的网络命名空间中，并在端口 `9580` 暴露就绪探针。如果您想将其部署在宿主网络命名空间中，那么可以使用下面的选项进行配置。

--- a/docs/getting_started/interface_specification.md
+++ b/docs/getting_started/interface_specification.md
@@ -131,7 +131,8 @@ English | [简体中文](interface_specification.zh_CN.md)
 <br />- Within the same field, multiple rules are also in a logical OR relationship.
 <br />- Overlapping rules targeting the same Pod/Service/IP may cause unintended port combinations or conflicts.
 <br />- The system does NOT guarantee deduplication or conflict resolution for overlapping targets. Users must ensure that rules within these fields do NOT repeatedly define the same Pod/Service/IP to avoid unpredictable traffic control behavior.
-<br />- The toServices and toPods rules only take effect when Kubernetes is v1.21 or higher.
+<br />- The toServices rules only take effect when Kubernetes is v1.21 or higher.
+<br />- The toPods rules only take effect when the [Pod Egress Control feature](installation.md#enable-pod-egress-control) is enabled.
 
 ### Destination
 

--- a/docs/getting_started/interface_specification.zh_CN.md
+++ b/docs/getting_started/interface_specification.zh_CN.md
@@ -131,7 +131,8 @@
 <br />- 在同一字段内，多个规则间也处于逻辑“或”关系。
 <br />- 针对同一 Pod、Service、IP 的重叠规则可能会导致意外的端口组合或冲突。
 <br />- 系统不保证对重叠目标进行重复数据删除或冲突解决。用户必须确保这些字段中的规则不会重复定义相同的 Pod、Service、IP，以避免出现不可预测的流量控制行为。
-<br />- toServices 和 toPods 规则仅在 Kubernetes 版本为 1.21 或更高版本时生效。
+<br />- toServices 规则仅在 Kubernetes 版本为 1.21 或更高版本时生效。
+<br />- toPods 规则仅在[启用 Pod Egress Control 功能](installation.zh_CN.md#开启-pod-出口控制) 时生效。
 
 ### Destination
 

--- a/internal/profile/bpf/bpf_test.go
+++ b/internal/profile/bpf/bpf_test.go
@@ -34,7 +34,7 @@ func TestGenerateRawNetworkEgressRule_1(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, uint32(bpfenforcer.Ipv6Match|bpfenforcer.PreciseMatch), bpfContent.Networks[0].Flags)
@@ -56,7 +56,7 @@ func TestGenerateRawNetworkEgressRule_2(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortMatch))
@@ -78,7 +78,7 @@ func TestGenerateRawNetworkEgressRule_3(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PortMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match))
@@ -100,7 +100,7 @@ func TestGenerateRawNetworkEgressRule_4(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PortRangeMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match))
@@ -128,7 +128,7 @@ func TestGenerateRawNetworkEgressRule_5(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PortsMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match))
@@ -151,7 +151,7 @@ func TestGenerateRawNetworkEgressRule_6(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortRangeMatch))
@@ -181,7 +181,7 @@ func TestGenerateRawNetworkEgressRule_7(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortsMatch))
@@ -200,7 +200,7 @@ func TestGenerateRawNetworkEgressRule_8(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 2)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortsMatch))
@@ -236,7 +236,7 @@ func TestGenerateRawNetworkEgressRule_9(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 2)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.CidrMatch|bpfenforcer.PortRangeMatch))
@@ -279,7 +279,7 @@ func TestGenerateRawNetworkEgressRule_10(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 3)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.Ipv4Match|bpfenforcer.PreciseMatch|bpfenforcer.PortRangeMatch))
@@ -316,7 +316,7 @@ func TestGenerateRawNetworkEgressRule_11(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PreciseMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match|bpfenforcer.PortsMatch))
@@ -339,7 +339,7 @@ func TestGenerateRawNetworkEgressRule_12(t *testing.T) {
 	}
 
 	bpfContent := &varmor.BpfContent{}
-	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, &varmortypes.EgressInfo{})
+	err := generateRawNetworkEgressRule(nil, bpfContent, &rule, false, false, &varmortypes.EgressInfo{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(bpfContent.Networks), 1)
 	assert.Equal(t, bpfContent.Networks[0].Flags, uint32(bpfenforcer.PodSelfIPMatch|bpfenforcer.Ipv4Match|bpfenforcer.Ipv6Match|bpfenforcer.PortMatch))

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -61,7 +61,8 @@ func GenerateProfile(
 	policy varmor.Policy,
 	name string, namespace string,
 	complete bool,
-	enablePodServiceEgressControl bool,
+	enableServiceEgressControl bool,
+	enablePodEgressControl bool,
 	logger logr.Logger) (*varmor.Profile, *varmortypes.EgressInfo, error) {
 	var err error
 
@@ -142,7 +143,7 @@ func GenerateProfile(
 		// BPF
 		if (e & varmortypes.BPF) != 0 {
 			var bpfContent varmor.BpfContent
-			err = bpfprofile.GenerateEnhanceProtectProfile(kubeClient, policy.EnhanceProtect, &bpfContent, enablePodServiceEgressControl, &egressInfo)
+			err = bpfprofile.GenerateEnhanceProtectProfile(kubeClient, policy.EnhanceProtect, &bpfContent, enableServiceEgressControl, enablePodEgressControl, &egressInfo)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -283,7 +284,8 @@ func NewArmorProfile(
 	varmorInterface varmorinterface.CrdV1beta1Interface,
 	obj interface{},
 	clusterScope bool,
-	enablePodServiceEgressControl bool,
+	enableServiceEgressControl bool,
+	enablePodEgressControl bool,
 	logger logr.Logger) (*varmor.ArmorProfile, *varmortypes.EgressInfo, error) {
 
 	var ap varmor.ArmorProfile
@@ -310,7 +312,7 @@ func NewArmorProfile(
 		}
 		ap.Finalizers = []string{"varmor.org/ap-protection"}
 
-		profile, egressInfo, err = GenerateProfile(kubeClient, varmorInterface, vcp.Spec.Policy, ap.Name, ap.Namespace, false, enablePodServiceEgressControl, logger)
+		profile, egressInfo, err = GenerateProfile(kubeClient, varmorInterface, vcp.Spec.Policy, ap.Name, ap.Namespace, false, enableServiceEgressControl, enablePodEgressControl, logger)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -342,7 +344,7 @@ func NewArmorProfile(
 		}
 		ap.Finalizers = []string{"varmor.org/ap-protection"}
 
-		profile, egressInfo, err = GenerateProfile(kubeClient, varmorInterface, vp.Spec.Policy, ap.Name, ap.Namespace, false, enablePodServiceEgressControl, logger)
+		profile, egressInfo, err = GenerateProfile(kubeClient, varmorInterface, vp.Spec.Policy, ap.Name, ap.Namespace, false, enableServiceEgressControl, enablePodEgressControl, logger)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/status/apis/v1/manager.go
+++ b/internal/status/apis/v1/manager.go
@@ -641,7 +641,7 @@ func (m *StatusManager) reconcileStatus(stopCh <-chan struct{}) {
 			}
 
 			apName := varmorprofile.GenerateArmorProfileName(namespace, vpName, clusterScope)
-			profile, _, err := varmorprofile.GenerateProfile(nil, m.varmorInterface, vPolicy, apName, namespace, true, false, logger)
+			profile, _, err := varmorprofile.GenerateProfile(nil, m.varmorInterface, vPolicy, apName, namespace, true, false, false, logger)
 			if err != nil {
 				logger.Error(err, "varmorprofile.GenerateProfile()")
 				break

--- a/manifests/varmor/templates/daemonsets/agent.yaml
+++ b/manifests/varmor/templates/daemonsets/agent.yaml
@@ -40,15 +40,14 @@ spec:
         image: "{{ .Values.image.registry }}/{{ .Values.image.namespace }}/{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
         command: ["/varmor/vArmor", "--agent"]
-        {{- if or .Values.jsonLogFormat.enabled .Values.agent.args .Values.behaviorModeling.enabled .Values.bpfLsmEnforcer.enabled .Values.unloadAllAaProfiles.enabled .Values.removeAllSeccompProfiles.enabled }}
         args:
-          {{- if .Values.jsonLogFormat.enabled }}
-            {{- with .Values.jsonLogFormat.args }}
+          {{- if .Values.agent.args }}
+            {{- with .Values.agent.args }}
               {{- toYaml . | nindent 8 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.agent.args }}
-            {{- with .Values.agent.args }}
+          {{- if .Values.jsonLogFormat.enabled }}
+            {{- with .Values.jsonLogFormat.args }}
               {{- toYaml . | nindent 8 }}
             {{- end }}
           {{- end }}
@@ -72,7 +71,6 @@ spec:
               {{- toYaml . | nindent 8 }}
             {{- end }}
           {{- end }}
-        {{- end }}
         env:
         - name: NODE_NAME
           valueFrom:

--- a/manifests/varmor/templates/deployments/manager.yaml
+++ b/manifests/varmor/templates/deployments/manager.yaml
@@ -53,10 +53,15 @@ spec:
             {{- end }}
           {{- end }}
           {{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version }}
-            {{- if .Values.podServiceEgressControl.enabled }}
-              {{- with .Values.manager.podServiceEgressControl.args }}
+            {{- if .Values.serviceEgressControl.enabled }}
+              {{- with .Values.manager.serviceEgressControl.args }}
                 {{- toYaml . | nindent 8 }}
               {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.podEgressControl.enabled }}
+            {{- with .Values.manager.podEgressControl.args }}
+              {{- toYaml . | nindent 8 }}
             {{- end }}
           {{- end }}
           {{- if .Values.restartExistWorkloads.enabled }}

--- a/manifests/varmor/templates/deployments/manager.yaml
+++ b/manifests/varmor/templates/deployments/manager.yaml
@@ -35,7 +35,6 @@ spec:
         image: "{{ .Values.image.registry }}/{{ .Values.image.namespace }}/{{ .Values.manager.image.name }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
         command: ["/varmor/vArmor"]
-        {{- if or .Values.manager.args .Values.bpfLsmEnforcer.enabled .Values.behaviorModeling.enabled .Values.podServiceEgressControl.enabled .Values.restartExistWorkloads.enabled .Values.bpfExclusiveMode.enabled .Values.metrics.enabled .Values.jsonLogFormat.enabled }}
         args:
           {{- if .Values.manager.args }}
             {{- with .Values.manager.args }}
@@ -84,7 +83,6 @@ spec:
               {{- toYaml . | nindent 8 }}
             {{- end }}
           {{- end }}
-        {{- end }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/manifests/varmor/templates/rbac/manager-clusterrole.yaml
+++ b/manifests/varmor/templates/rbac/manager-clusterrole.yaml
@@ -34,8 +34,11 @@ rules:
   - get
   - list
   - watch
-{{- if .Values.podServiceEgressControl.enabled }}
-  {{- toYaml .Values.manager.podServiceEgressControl.clusterrules | nindent 0  }}
+{{- if .Values.serviceEgressControl.enabled }}
+  {{- toYaml .Values.manager.serviceEgressControl.clusterrules | nindent 0  }}
+{{- end }}
+{{- if .Values.podEgressControl.enabled }}
+  {{- toYaml .Values.manager.podEgressControl.clusterrules | nindent 0  }}
 {{- end }}
 - apiGroups:
   - crd.varmor.org

--- a/manifests/varmor/values.yaml
+++ b/manifests/varmor/values.yaml
@@ -27,8 +27,11 @@ bpfLsmEnforcer:
 behaviorModeling:
   enabled: false
 
-podServiceEgressControl:
+serviceEgressControl:
   enabled: true
+
+podEgressControl:
+  enabled: false
 
 unloadAllAaProfiles:
   enabled: false
@@ -122,17 +125,29 @@ manager:
       claimName: varmor-manager-apmdata-pvc
       name: apmdata
 
-  podServiceEgressControl:
+  serviceEgressControl:
     args:
-    - --enablePodServiceEgressControl
+    - --enableServiceEgressControl
     clusterrules:
     - apiGroups:
       - ""
       - "discovery.k8s.io"
       resources:
-      - pods
       - services
       - endpointslices
+      verbs:
+      - get
+      - list
+      - watch
+
+  podEgressControl:
+    args:
+    - --enablePodEgressControl
+    clusterrules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
       verbs:
       - get
       - list

--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -113,14 +113,14 @@ vArmor allows users to decide whether to perform a rolling restart on all target
 --set restartExistWorkloads.enabled=false
 ```
 
-#### Disable Pod and Service Egress Control
-The feature extends network access control to restrict container access to specific Pods and Services. You can use the following option to disable it. Default: enabled.
+#### Enable Pod Egress Control
+The feature extends network access control to restrict container access to specific Pod IPs. You can use the following option to enable it. Default: disabled.
 
 ```bash
---set podServiceEgressControl.enabled=false
+--set podEgressControl.enabled=true
 ```
 
-The feature is currently only supported by the BPF enforcer and requires Kubernetes v1.21 or higher.
+The feature is currently only supported by the BPF enforcer. When enabling this feature, you may need to allocate more memory to the manager to watch pods. It is not recommended to enable this feature in large-scale clusters (such as those with 10k+ nodes).
 
 #### Run Agent in HostNetwork Mode
 The agent runs in its own network namespace and exposes the readinessProbe on port `9580` by default. If you want to run it in the host's network namespace, you can use following options.

--- a/website/docs/getting_started/interface_specification.md
+++ b/website/docs/getting_started/interface_specification.md
@@ -134,7 +134,8 @@ description: The interface specification of vArmor.
 <br />- Within the same field, multiple rules are also in a logical OR relationship.
 <br />- Overlapping rules targeting the same Pod/Service/IP may cause unintended port combinations or conflicts.
 <br />- The system does NOT guarantee deduplication or conflict resolution for overlapping targets. Users must ensure that rules within these fields do NOT repeatedly define the same Pod/Service/IP to avoid unpredictable traffic control behavior.
-<br />- The toServices and toPods rules only take effect when Kubernetes is v1.21 or higher.
+<br />- The toServices rules only take effect when Kubernetes is v1.21 or higher.
+<br />- The toPods rules only take effect when the [Pod Egress Control feature](installation.md#enable-pod-egress-control) is enabled.
 
 ### Destination
 

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/installation.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/installation.md
@@ -111,14 +111,14 @@ vArmor 只会对包含此 label 的 Workloads 开启沙箱防护。你可以使�
 --set restartExistWorkloads.enabled=false
 ```
 
-#### 关闭 Pod 和 Service 出口控制
-此功能扩展了网络访问控制，以限制容器对特定 Pod 和 Service 的访问。您可以使用下面的选项关闭它。默认值：开启。
+#### 开启 Pod 出口控制
+此功能扩展了网络访问控制，以限制容器对特定 Pod IPs 的访问。您可以使用下面的选项关闭它。默认值：开启。
 
 ```bash
---set podServiceEgressControl.enabled=false
+--set podEgressControl.enabled=false
 ```
 
-当前仅 BPF enforcer 支持此功能，并且需要 Kubernetes v1.21 及以上版本。
+当前仅 BPF enforcer 支持此功能。开启此功能时，您可能需要为 manager 设置更多内存，以便其 watch pods 变化。不建议在大规模集群（如 10k+ 节点）中启用此功能。
 
 #### 在宿主机网络命名空间中运行 Agent
 vArmor 的 Agent 默认运行在独立的网络命名空间中，并在端口 `9580` 暴露就绪探针。如果您想将其部署在宿主网络命名空间中，那么可以使用下面的选项进行配置。

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/interface_specification.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/interface_specification.md
@@ -134,7 +134,8 @@ description: vArmor 的接口规范。
 <br />- 在同一字段内，多个规则间也处于逻辑“或”关系。
 <br />- 针对同一 Pod、Service、IP 的重叠规则可能会导致意外的端口组合或冲突。
 <br />- 系统不保证对重叠目标进行重复数据删除或冲突解决。用户必须确保这些字段中的规则不会重复定义相同的 Pod、Service、IP，以避免出现不可预测的流量控制行为。
-<br />- toServices 和 toPods 规则仅在 Kubernetes 版本为 1.21 或更高版本时生效。
+<br />- toServices 规则仅在 Kubernetes 版本为 1.21 或更高版本时生效。
+<br />- toPods 规则仅在启用 [Pod Egress Control 功能](installation.md#开启-pod-出口控制)时生效。
 
 ### Destination
 

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.9/getting_started/installation.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.9/getting_started/installation.md
@@ -111,14 +111,14 @@ vArmor 只会对包含此 label 的 Workloads 开启沙箱防护。你可以使�
 --set restartExistWorkloads.enabled=false
 ```
 
-#### 关闭 Pod 和 Service 出口控制
-此功能扩展了网络访问控制，以限制容器对特定 Pod 和 Service 的访问。您可以使用下面的选项关闭它。默认值：开启。
+#### 开启 Pod 出口控制
+此功能扩展了网络访问控制，以限制容器对特定 Pod IPs 的访问。您可以使用下面的选项关闭它。默认值：开启。
 
 ```bash
---set podServiceEgressControl.enabled=false
+--set podEgressControl.enabled=false
 ```
 
-当前仅 BPF enforcer 支持此功能，并且需要 Kubernetes v1.21 及以上版本。
+当前仅 BPF enforcer 支持此功能。开启此功能时，您可能需要为 manager 设置更多内存，以便其 watch pods 变化。不建议在大规模集群（如 10k+ 节点）中启用此功能。
 
 #### 在宿主机网络命名空间中运行 Agent
 vArmor 的 Agent 默认运行在独立的网络命名空间中，并在端口 `9580` 暴露就绪探针。如果您想将其部署在宿主网络命名空间中，那么可以使用下面的选项进行配置。

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.9/getting_started/interface_specification.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.9/getting_started/interface_specification.md
@@ -134,7 +134,8 @@ description: vArmor 的接口规范。
 <br />- 在同一字段内，多个规则间也处于逻辑“或”关系。
 <br />- 针对同一 Pod、Service、IP 的重叠规则可能会导致意外的端口组合或冲突。
 <br />- 系统不保证对重叠目标进行重复数据删除或冲突解决。用户必须确保这些字段中的规则不会重复定义相同的 Pod、Service、IP，以避免出现不可预测的流量控制行为。
-<br />- toServices 和 toPods 规则仅在 Kubernetes 版本为 1.21 或更高版本时生效。
+<br />- toServices 规则仅在 Kubernetes 版本为 1.21 或更高版本时生效。
+<br />- toPods 规则仅在启用 [Pod Egress Control 功能](installation.md#开启-pod-出口控制)时生效。
 
 ### Destination
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5348,9 +5348,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -5705,160 +5705,160 @@
       }
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmmirror.com/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmmirror.com/@xtuc/long/-/long-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
     },
@@ -5906,15 +5906,27 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -5979,9 +5991,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -6203,7 +6215,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT",
       "peer": true
@@ -6245,14 +6257,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -7008,7 +7020,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "peer": true,
@@ -7955,7 +7967,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
       "peer": true,
@@ -8237,13 +8249,13 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmmirror.com/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -8289,9 +8301,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -8308,7 +8320,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "peer": true,
@@ -8836,9 +8848,9 @@
       }
     },
     "node_modules/file-loader/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -8971,9 +8983,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -8991,9 +9003,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9192,7 +9204,7 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmmirror.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
@@ -9388,7 +9400,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
       "peer": true,
@@ -10719,12 +10731,16 @@
       "license": "MIT"
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmmirror.com/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/loader-utils": {
@@ -13477,9 +13493,9 @@
       }
     },
     "node_modules/null-loader/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -15582,9 +15598,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -17263,12 +17279,16 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmmirror.com/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser": {
@@ -17290,16 +17310,16 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmmirror.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
-      "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
+      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.20",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
-        "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
-        "terser": "^5.26.0"
+        "schema-utils": "^4.3.0",
+        "serialize-javascript": "^6.0.2",
+        "terser": "^5.31.1"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -17323,31 +17343,6 @@
         }
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmmirror.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
     "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmmirror.com/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -17360,30 +17355,6 @@
       },
       "engines": {
         "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmmirror.com/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/supports-color": {
@@ -17933,9 +17904,9 @@
       }
     },
     "node_modules/url-loader/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -18108,9 +18079,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmmirror.com/watchpack/-/watchpack-2.4.2.tgz",
-      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -18146,34 +18117,36 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.105.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
+      "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.14.0",
-        "browserslist": "^4.24.0",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.19.0",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
+        "loader-runner": "^4.3.1",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.16",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.3"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -18412,44 +18385,13 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmmirror.com/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmmirror.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -18470,24 +18412,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmmirror.com/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/webpackbar": {

--- a/website/versioned_docs/version-v0.9/getting_started/installation.md
+++ b/website/versioned_docs/version-v0.9/getting_started/installation.md
@@ -113,14 +113,14 @@ vArmor allows users to decide whether to perform a rolling restart on all target
 --set restartExistWorkloads.enabled=false
 ```
 
-#### Disable Pod and Service Egress Control
-The feature extends network access control to restrict container access to specific Pods and Services. You can use the following option to disable it. Default: enabled.
+#### Enable Pod Egress Control
+The feature extends network access control to restrict container access to specific Pod IPs. You can use the following option to enable it. Default: disabled.
 
 ```bash
---set podServiceEgressControl.enabled=false
+--set podEgressControl.enabled=true
 ```
 
-The feature is currently only supported by the BPF enforcer and requires Kubernetes v1.21 or higher.
+The feature is currently only supported by the BPF enforcer. When enabling this feature, you may need to allocate more memory to the manager to watch pods. It is not recommended to enable this feature in large-scale clusters (such as those with 10k+ nodes).
 
 #### Run Agent in HostNetwork Mode
 The agent runs in its own network namespace and exposes the readinessProbe on port `9580` by default. If you want to run it in the host's network namespace, you can use following options.

--- a/website/versioned_docs/version-v0.9/getting_started/interface_specification.md
+++ b/website/versioned_docs/version-v0.9/getting_started/interface_specification.md
@@ -134,7 +134,8 @@ description: The interface specification of vArmor.
 <br />- Within the same field, multiple rules are also in a logical OR relationship.
 <br />- Overlapping rules targeting the same Pod/Service/IP may cause unintended port combinations or conflicts.
 <br />- The system does NOT guarantee deduplication or conflict resolution for overlapping targets. Users must ensure that rules within these fields do NOT repeatedly define the same Pod/Service/IP to avoid unpredictable traffic control behavior.
-<br />- The toServices and toPods rules only take effect when Kubernetes is v1.21 or higher.
+<br />- The toServices rules only take effect when Kubernetes is v1.21 or higher.
+<br />- The toPods rules only take effect when the [Pod Egress Control feature](installation.md#enable-pod-egress-control) is enabled.
 
 ### Destination
 


### PR DESCRIPTION
# What this PR does
This PR refactors the combined `PodServiceEgressControl` feature gate into two separate feature gates: `ServiceEgressControl` and `PodEgressControl`. This provides more granular control over egress control features and allows users to enable only the specific capabilities they need.

# Changes
- Feature Gate Separation/ Helm Values
  - Split enablePodServiceEgressControl into enableServiceEgressControl and enablePodEgressControl
  - **ServiceEgressControl is now enabled by default** (maintains backward compatibility)
  - **PodEgressControl is now disabled by default** (opt-in feature due to resource overhead)

- IPWatcher Improvements:
  - Modified NewIPWatcher to accept optional informers (Pod, Service, EndpointSlice)
  - Each informer is now conditionally initialized based on enabled features
  - Event handlers are only registered for enabled informers

- Controller Updates:
  - Updated ClusterPolicyController and PolicyController to accept both feature flags
  - Modified NewArmorProfile and GenerateProfile signatures to include both flags
  - Updated profile generation logic to check feature flags independently

- Documentation Updates
  - Updated installation guides (English and Chinese)
  - Updated interface specification with separate feature requirements
  - Added warnings about Pod Egress Control resource requirements
  - Updated all versioned documentation (current, v0.9)

# Motivation
The original combined feature gate forced users to enable both Service and Pod egress control together. This separation:
1. Reduces Resource Overhead: Pod Egress Control requires watching all Pods in the cluster, which can be resource-intensive in large-scale clusters (10k+ nodes). Users who only need Service-based egress control can now avoid this overhead.
2. Granular Control: Users can enable only the features they need, improving flexibility and reducing unnecessary watch operations.
3. Better Default Behavior: Service Egress Control (enabled by default) provides most use cases, while Pod Egress Control (disabled by default) remains opt-in for users who specifically need Pod IP-based restrictions.

# Breaking Changes
- Helm value: `podServiceEgressControl.enabled` is replaced by `serviceEgressControl.enabled` and `podEgressControl.enabled`
- Command-line flag: `--enablePodServiceEgressControl` is no longer supported

**Users who previously enabled PodServiceEgressControl should now enable both ServiceEgressControl and PodEgressControl to maintain the same behavior.**