### PR TITLE
fix: correct DaemonSet pointer comparison in updateWorkloadAnnotationsAndEnv

### DIFF
--- a/internal/policy/update.go
+++ b/internal/policy/update.go
@@ -871,7 +871,7 @@ func updateWorkloadAnnotationsAndEnv(
 
 				daemonOld := daemon.DeepCopy()
 				modifyDaemonSetAnnotationsAndEnv(enforcer, mode, target, proxyConfig, daemon, profileName, bpfExclusiveMode)
-				if reflect.DeepEqual(daemonOld, &daemon) {
+				if reflect.DeepEqual(daemonOld, daemon) {
 					return nil
 				}
 				daemon.Spec.Template.Annotations["controller.varmor.org/restartedAt"] = time.Now().Format(time.RFC3339)


### PR DESCRIPTION
## Summary

- Fix `reflect.DeepEqual(daemonOld, &daemon)` in `internal/policy/update.go:874` which compared `*DaemonSet` with `**DaemonSet`, always returning `false`
- This caused unnecessary rolling restarts of DaemonSets on every reconciliation, even when nothing changed
- Fixed to `reflect.DeepEqual(daemonOld, daemon)` matching the Deployment/StatefulSet pattern

## Test plan

- [x] `go vet` passes for all modified packages on `GOOS=linux`
- [x] Manual verification: create a VarmorPolicy targeting a DaemonSet and verify no unnecessary rolling updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)