### PR TITLE
fix: remove status comparison from policy update event filter

### DIFF
--- a/internal/policy/clusterpolicy_controller.go
+++ b/internal/policy/clusterpolicy_controller.go
@@ -135,8 +135,7 @@ func (c *ClusterPolicyController) updateVarmorClusterPolicy(oldObj, newObj inter
 	newVcp := newObj.(*varmor.VarmorClusterPolicy)
 
 	if newVcp.ResourceVersion == oldVcp.ResourceVersion ||
-		reflect.DeepEqual(newVcp.Spec, oldVcp.Spec) ||
-		!reflect.DeepEqual(newVcp.Status, oldVcp.Status) {
+		reflect.DeepEqual(newVcp.Spec, oldVcp.Spec) {
 		logger.V(2).Info("nothing need to be updated")
 	} else {
 		logger.V(2).Info("enqueue VarmorClusterPolicy")

--- a/internal/policy/policy_controller.go
+++ b/internal/policy/policy_controller.go
@@ -139,8 +139,7 @@ func (c *PolicyController) updateVarmorPolicy(oldObj, newObj interface{}) {
 	newVp := newObj.(*varmor.VarmorPolicy)
 
 	if newVp.ResourceVersion == oldVp.ResourceVersion ||
-		reflect.DeepEqual(newVp.Spec, oldVp.Spec) ||
-		!reflect.DeepEqual(newVp.Status, oldVp.Status) {
+		reflect.DeepEqual(newVp.Spec, oldVp.Spec) {
 		logger.V(2).Info("nothing need to be updated")
 	} else {
 		logger.V(2).Info("enqueue VarmorPolicy")


### PR DESCRIPTION
## Summary

- Fix update event filter in `internal/policy/policy_controller.go:141` and `internal/policy/clusterpolicy_controller.go:137`
- The condition `!reflect.DeepEqual(newVp.Status, oldVp.Status)` caused the entire OR to be true when both spec AND status changed, skipping real spec changes
- This meant policy spec updates could be silently ignored when the status was simultaneously updated by the reconciliation loop
- Removed the status comparison from the skip condition

## Test plan

- [x] `go vet` passes for all modified packages on `GOOS=linux`
- [x] Manual verification: update a VarmorPolicy spec while status is also changing, verify the update is processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)