### PR TITLE
fix: add missing return after http.Error in webhook body parsing

### DIFF
--- a/internal/webhooks/common.go
+++ b/internal/webhooks/common.go
@@ -40,6 +40,7 @@ func bodyToAdmissionReview(request *http.Request, writer http.ResponseWriter, lo
 	if err != nil {
 		logger.Info("failed to read HTTP body", "req", request.URL.String())
 		http.Error(writer, "failed to read HTTP body", http.StatusBadRequest)
+		return nil
 	}
 
 	contentType := request.Header.Get("Content-Type")


### PR DESCRIPTION
## Summary

- Fix missing `return nil` after `http.Error()` in `internal/webhooks/common.go:42`
- After the error response for failed body read, execution continued to unmarshal an empty body
- Added `return nil` to prevent processing of invalid requests

## Test plan

- [x] `go vet` passes for all modified packages on `GOOS=linux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)