### PR TITLE
fix: correct logger name for Seccomp profile cleanup

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -712,7 +712,7 @@ func (agent *Agent) CleanUp() {
 	}
 
 	if agent.removeAllSeccompProfiles {
-		agent.log.WithName("APPARMOR-ENFORCER").Info("remove all Seccomp profiles")
+		agent.log.WithName("SECCOMP-ENFORCER").Info("remove all Seccomp profiles")
 		varmorseccomp.RemoveAllSeccompProfiles(agent.seccompProfileDir)
 	}
 


### PR DESCRIPTION
## Summary

- Fix wrong logger name in `internal/agent/agent.go:715` — used `APPARMOR-ENFORCER` instead of `SECCOMP-ENFORCER` for Seccomp profile removal log

## Test plan

- [x] `go vet` passes for all modified packages on `GOOS=linux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)