### PR TITLE
fix: add thread-safety to PolicyCacher with sync.RWMutex

### DIFF
--- a/internal/policycacher/policycacher.go
+++ b/internal/policycacher/policycacher.go
@@ -17,6 +17,7 @@ package policycacher
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/go-logr/logr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -29,6 +30,7 @@ import (
 )
 
 type PolicyCacher struct {
+	mutex                    sync.RWMutex
 	vcpInformer              varmorinformer.VarmorClusterPolicyInformer
 	vcpLister                varmorlister.VarmorClusterPolicyLister
 	vcpInformerSynced        cache.InformerSynced
@@ -80,6 +82,8 @@ func (c *PolicyCacher) addVarmorClusterPolicy(obj interface{}) {
 		logger.Error(err, "cache.MetaNamespaceKeyFunc()")
 		return
 	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	c.ClusterPolicyTargets[key] = vcp.Spec.DeepCopy().Target
 	c.ClusterPolicyEnforcer[key] = vcp.Spec.Policy.Enforcer
 	c.ClusterPolicyMode[key] = vcp.Spec.Policy.Mode
@@ -94,6 +98,8 @@ func (c *PolicyCacher) updateVarmorClusterPolicy(oldObj, newObj interface{}) {
 		logger.Error(err, "cache.MetaNamespaceKeyFunc()")
 		return
 	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Don't update the enforcer if the activated AppArmor or Seccomp enforcer was removed.
 	if e, ok := c.ClusterPolicyEnforcer[key]; ok {
 		oldEnforcers := varmortypes.GetEnforcerType(e)
@@ -114,6 +120,8 @@ func (c *PolicyCacher) deleteVarmorClusterPolicy(obj interface{}) {
 		logger.Error(err, "cache.MetaNamespaceKeyFunc()")
 		return
 	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	delete(c.ClusterPolicyTargets, key)
 	delete(c.ClusterPolicyEnforcer, key)
 	delete(c.ClusterPolicyMode, key)
@@ -128,6 +136,8 @@ func (c *PolicyCacher) addVarmorPolicy(obj interface{}) {
 		logger.Error(err, "cache.MetaNamespaceKeyFunc()")
 		return
 	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	c.PolicyTargets[key] = vp.Spec.DeepCopy().Target
 	c.PolicyEnforcer[key] = vp.Spec.Policy.Enforcer
 	c.PolicyMode[key] = vp.Spec.Policy.Mode
@@ -142,6 +152,8 @@ func (c *PolicyCacher) updateVarmorPolicy(oldObj, newObj interface{}) {
 		logger.Error(err, "cache.MetaNamespaceKeyFunc()")
 		return
 	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Don't update the enforcer if the activated AppArmor or Seccomp enforcer was removed.
 	if e, ok := c.PolicyEnforcer[key]; ok {
 		oldEnforcers := varmortypes.GetEnforcerType(e)
@@ -162,10 +174,54 @@ func (c *PolicyCacher) deleteVarmorPolicy(obj interface{}) {
 		logger.Error(err, "cache.MetaNamespaceKeyFunc()")
 		return
 	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	delete(c.PolicyTargets, key)
 	delete(c.PolicyEnforcer, key)
 	delete(c.PolicyMode, key)
 	delete(c.PolicyProxyConfig, key)
+}
+
+// GetClusterPolicyEntry returns the cached enforcer, mode, and proxy config for a cluster-scoped policy key.
+// It is safe to call from multiple goroutines.
+func (c *PolicyCacher) GetClusterPolicyEntry(key string) (string, varmor.VarmorPolicyMode, *varmor.NetworkProxyConfig) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.ClusterPolicyEnforcer[key], c.ClusterPolicyMode[key], c.ClusterPolicyProxyConfig[key]
+}
+
+// GetPolicyEntry returns the cached enforcer, mode, and proxy config for a namespace-scoped policy key.
+// It is safe to call from multiple goroutines.
+func (c *PolicyCacher) GetPolicyEntry(key string) (string, varmor.VarmorPolicyMode, *varmor.NetworkProxyConfig) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.PolicyEnforcer[key], c.PolicyMode[key], c.PolicyProxyConfig[key]
+}
+
+// RangeClusterPolicyTargets iterates over all cluster-scoped policy targets.
+// It is safe to call from multiple goroutines. The lock is held during iteration,
+// so the callback should not block for long.
+func (c *PolicyCacher) RangeClusterPolicyTargets(fn func(key string, target varmor.Target) bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	for key, target := range c.ClusterPolicyTargets {
+		if !fn(key, target) {
+			break
+		}
+	}
+}
+
+// RangePolicyTargets iterates over all namespace-scoped policy targets.
+// It is safe to call from multiple goroutines. The lock is held during iteration,
+// so the callback should not block for long.
+func (c *PolicyCacher) RangePolicyTargets(fn func(key string, target varmor.Target) bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	for key, target := range c.PolicyTargets {
+		if !fn(key, target) {
+			break
+		}
+	}
 }
 
 func (c *PolicyCacher) Run(stopCh <-chan struct{}) {

--- a/internal/webhooks/mutation.go
+++ b/internal/webhooks/mutation.go
@@ -55,14 +55,10 @@ func (ws *WebhookServer) matchAndPatch(request *admissionv1.AdmissionRequest, ke
 	var mode varmor.VarmorPolicyMode
 	var networkProxyConfig *varmor.NetworkProxyConfig
 	if clusterScope {
-		enforcer = ws.policyCacher.ClusterPolicyEnforcer[key]
-		mode = ws.policyCacher.ClusterPolicyMode[key]
+		enforcer, mode, networkProxyConfig = ws.policyCacher.GetClusterPolicyEntry(key)
 		policyNamespace = varmorconfig.Namespace
-		networkProxyConfig = ws.policyCacher.ClusterPolicyProxyConfig[key]
 	} else {
-		enforcer = ws.policyCacher.PolicyEnforcer[key]
-		mode = ws.policyCacher.PolicyMode[key]
-		networkProxyConfig = ws.policyCacher.PolicyProxyConfig[key]
+		enforcer, mode, networkProxyConfig = ws.policyCacher.GetPolicyEntry(key)
 	}
 
 	obj, err := ws.deserializeWorkload(request)

--- a/internal/webhooks/server.go
+++ b/internal/webhooks/server.go
@@ -197,18 +197,22 @@ func (ws *WebhookServer) handlerFunc(handler func(request *admissionv1.Admission
 func (ws *WebhookServer) resourceMutation(request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	logger := ws.log.WithName("resourceMutation()")
 
-	for key, target := range ws.policyCacher.ClusterPolicyTargets {
-		response := ws.matchAndPatch(request, key, target, logger)
-		if response != nil {
-			return response
-		}
+	var clusterResponse *admissionv1.AdmissionResponse
+	ws.policyCacher.RangeClusterPolicyTargets(func(key string, target varmor.Target) bool {
+		clusterResponse = ws.matchAndPatch(request, key, target, logger)
+		return clusterResponse == nil
+	})
+	if clusterResponse != nil {
+		return clusterResponse
 	}
 
-	for key, target := range ws.policyCacher.PolicyTargets {
-		response := ws.matchAndPatch(request, key, target, logger)
-		if response != nil {
-			return response
-		}
+	var policyResponse *admissionv1.AdmissionResponse
+	ws.policyCacher.RangePolicyTargets(func(key string, target varmor.Target) bool {
+		policyResponse = ws.matchAndPatch(request, key, target, logger)
+		return policyResponse == nil
+	})
+	if policyResponse != nil {
+		return policyResponse
 	}
 
 	logger.V(2).Info("no mutation required")


### PR DESCRIPTION
## Summary

- Add `sync.RWMutex` to `PolicyCacher` struct in `internal/policycacher/policycacher.go`
- Maps were read by webhook goroutines and written by informer handlers without synchronization, which can cause fatal panics in Go
- Add mutex Lock/Unlock to all map write operations (add/update/delete handlers)
- Add thread-safe accessor methods: `GetClusterPolicyEntry`, `GetPolicyEntry`, `RangeClusterPolicyTargets`, `RangePolicyTargets`
- Update `internal/webhooks/mutation.go` to use `GetClusterPolicyEntry`/`GetPolicyEntry` instead of direct map access
- Update `internal/webhooks/server.go` to use `RangeClusterPolicyTargets`/`RangePolicyTargets` instead of direct map iteration

## Test plan

- [x] `go vet` passes for all modified packages on `GOOS=linux`
- [ ] Verify webhook server handles concurrent requests without panics under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)