### PR TITLE
test: validate e2e testcase comment handling

### DIFF
--- a/test/e2e/testcases/apparmor.sh
+++ b/test/e2e/testcases/apparmor.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 # AppArmor enforcement test case configuration
+# No-op comment used for CI approval-path validation.
 
 # Test name
 TEST_NAME="apparmor-sa-token-protection"


### PR DESCRIPTION
This draft PR contains a no-op comment-only change under test/e2e/testcases to validate CI behavior for external contributions.