### PR TITLE
fix(networkproxy): translate catch-all host "*" to match-any everywhere

### DIFF
--- a/internal/networkproxy/profile/translator.go
+++ b/internal/networkproxy/profile/translator.go
@@ -262,6 +262,16 @@ func isWildcardDomain(domain string) bool {
 	return strings.HasPrefix(domain, "*.")
 }
 
+// isMatchAllHost reports whether host is the catch-all wildcard "*", meaning
+// "match any host". This is distinct from a suffix wildcard like
+// "*.example.com" (handled by isWildcardDomain). A bare "*" must be rendered
+// as a match-any matcher (any: true); rendering it as a literal exact/prefix
+// string matcher would never match real SNI or :authority values, silently
+// disabling enforcement and audit for catch-all rules.
+func isMatchAllHost(host string) bool {
+	return host == "*"
+}
+
 func wildcardToSuffix(domain string) string {
 	return domain[1:] // "*.openai.com" -> ".openai.com"
 }
@@ -880,12 +890,16 @@ func httpRuleToSNIPermissions(r varmor.NetworkProxyHTTPRule) []Permission {
 
 	var sniRules []PermissionRule
 	for _, host := range r.Match.Hosts {
-		if isWildcardDomain(host) {
+		switch {
+		case isMatchAllHost(host):
+			// Catch-all "*": match any SNI. A literal exact:"*" never matches.
+			sniRules = append(sniRules, PermissionRule{Type: "any", Value: true})
+		case isWildcardDomain(host):
 			sniRules = append(sniRules, PermissionRule{
 				Type:  "requested_server_name",
 				Value: map[string]string{"suffix": wildcardToSuffix(host)},
 			})
-		} else {
+		default:
 			sniRules = append(sniRules, PermissionRule{
 				Type:  "requested_server_name",
 				Value: map[string]string{"exact": host},
@@ -1065,6 +1079,12 @@ func isDefaultHTTPPort(port uint16) bool {
 //
 // This eliminates dead rules by binding the port into the matcher value.
 func authorityMatcherForHostPort(host string, port uint16) PermissionRule {
+	if isMatchAllHost(host) {
+		// Catch-all "*": match any :authority. The TCP port is enforced
+		// separately via the destination_port rule, so the authority
+		// matcher is match-any. A literal exact/prefix on "*" never matches.
+		return PermissionRule{Type: "any", Value: true}
+	}
 	if isWildcardDomain(host) {
 		suffix := wildcardToSuffix(host) // "*.openai.com" -> ".openai.com"
 		if isDefaultHTTPPort(port) {
@@ -1118,6 +1138,11 @@ func authorityMatcherForHostPort(host string, port uint16) PermissionRule {
 func portAgnosticHostRules(hosts []string) []PermissionRule {
 	var rules []PermissionRule
 	for _, host := range hosts {
+		if isMatchAllHost(host) {
+			// Catch-all "*": match any :authority regardless of port.
+			rules = append(rules, PermissionRule{Type: "any", Value: true})
+			continue
+		}
 		if isWildcardDomain(host) {
 			suffix := wildcardToSuffix(host)
 			escapedSuffix := regexEscapeHost(suffix)

--- a/internal/networkproxy/profile/translator_mitm.go
+++ b/internal/networkproxy/profile/translator_mitm.go
@@ -268,7 +268,14 @@ func filterHTTPRulesForDomains(rules []varmor.NetworkProxyHTTPRule, domains []st
 		}
 		var keepHosts []string
 		for _, h := range r.Match.Hosts {
-			if domainSet[h] {
+			// A catch-all "*" host matches every domain, so it is reachable
+			// via every MITM chain. Keep it verbatim; downstream
+			// httpRuleToHTTPPermissions converts "*" into a match-any
+			// (any: true) :authority rule. Without this, "*" would fail the
+			// exact domainSet lookup, the whole rule would be dropped, and
+			// the MITM chain would emit no shadow RBAC / access_log -- so
+			// MITM'd domains produced no audit records for catch-all rules.
+			if isMatchAllHost(h) || domainSet[h] {
 				keepHosts = append(keepHosts, h)
 			}
 		}

--- a/internal/networkproxy/profile/translator_test.go
+++ b/internal/networkproxy/profile/translator_test.go
@@ -2185,3 +2185,141 @@ func TestAntiDomainFronting_MixedDomainsAndIPs(t *testing.T) {
 	assertContains(t, result.LDS, "Authorization", "must inject Authorization for openai")
 	assertContains(t, result.LDS, "X-Token", "must inject X-Token for IP")
 }
+
+// TestWildcardHostMatchAll verifies that a catch-all host "*" is translated
+// into a match-any RBAC rule (any: true) in BOTH the TLS (SNI) chain and the
+// HTTP (:authority) chain, rather than a literal exact:"*" string matcher.
+//
+// Regression for: a bare "*" host produced `requested_server_name: {exact: "*"}`
+// in the TLS chain RBAC shadow_rules. Envoy treats that as a literal string
+// comparison against the SNI, which never matches a real server name, so
+// catch-all audit/enforce rules silently produced no shadow metadata and no
+// audit logs for TLS traffic.
+func TestWildcardHostMatchAll(t *testing.T) {
+	cases := []struct {
+		name          string
+		defaultAction string
+		qualifiers    []string
+	}{
+		{"allow_default_audit", "allow", []string{"audit"}},
+		{"deny_default_allow_audit", "deny", []string{"allow", "audit"}},
+		{"allow_default_deny_audit", "allow", []string{"deny", "audit"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			egress := &varmor.NetworkProxyEgress{
+				DefaultAction: tc.defaultAction,
+				HTTPRules: []varmor.NetworkProxyHTTPRule{
+					{
+						Qualifiers: tc.qualifiers,
+						Match:      varmor.HTTPMatch{Hosts: []string{"*"}},
+					},
+				},
+			}
+			result, err := TranslateEgressRules(egress, 1, 15001, nil, testIPStack)
+			if err != nil {
+				t.Fatalf("TranslateEgressRules failed: %v", err)
+			}
+			// A literal exact:"*" SNI matcher never matches a real server name.
+			assertNotContains(t, result.LDS, `exact: "*"`,
+				"catch-all host must not become a literal exact:\"*\" matcher")
+			// The catch-all must materialize as a match-any rule.
+			assertContains(t, result.LDS, "any: true",
+				"catch-all host must produce a match-any (any: true) rule")
+		})
+	}
+}
+
+// TestWildcardHostMatchAllWithPort verifies the catch-all host "*" combined
+// with an explicit port still avoids the literal exact:"*" matcher and binds
+// the port via destination_port while keeping the authority match as any:true.
+func TestWildcardHostMatchAllWithPort(t *testing.T) {
+	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "allow",
+		HTTPRules: []varmor.NetworkProxyHTTPRule{
+			{
+				Qualifiers: []string{"audit"},
+				Match: varmor.HTTPMatch{
+					Hosts: []string{"*"},
+					Ports: []varmor.Port{{Port: 8443}},
+				},
+			},
+		},
+	}
+	result, err := TranslateEgressRules(egress, 1, 15001, nil, testIPStack)
+	if err != nil {
+		t.Fatalf("TranslateEgressRules failed: %v", err)
+	}
+	assertNotContains(t, result.LDS, `exact: "*"`,
+		"catch-all host with port must not become a literal exact:\"*\" matcher")
+	assertContains(t, result.LDS, "destination_port: 8443",
+		"explicit port must still be enforced via destination_port")
+}
+
+// TestMITMWildcardHostAudit verifies that a catch-all host "*" audit rule is
+// preserved on MITM filter chains. When a domain is BOTH a MITM target and
+// covered by a "*" httpRule, the MITM chain steals the traffic by SNI, so the
+// audit rule must survive filterHTTPRulesForDomains and materialize as a
+// shadow RBAC + access_log inside the MITM HCM.
+//
+// Regression for: filterHTTPRulesForDomains did an exact domainSet lookup on
+// each host. The literal "*" was never in the MITM domain set, so the whole
+// audit rule was dropped, the MITM HCM emitted no shadow RBAC / access_log,
+// and MITM'd domains (e.g. httpbin.org) produced no audit records.
+func TestMITMWildcardHostAudit(t *testing.T) {
+	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "allow",
+		HTTPRules: []varmor.NetworkProxyHTTPRule{
+			{
+				Qualifiers: []string{"audit"},
+				Match:      varmor.HTTPMatch{Hosts: []string{"*"}},
+			},
+		},
+	}
+	mitm := &MITMInput{
+		Domains: []string{"httpbin.org", "api.kimi.com"},
+		HeadersByDomain: map[string][]HeaderToAdd{
+			"httpbin.org": {{Name: "X-Request-Source", Value: "varmor-audit"}},
+		},
+	}
+	result, err := TranslateEgressRules(egress, 1, 15001, mitm, testIPStack)
+	if err != nil {
+		t.Fatalf("TranslateEgressRules failed: %v", err)
+	}
+
+	dnsChain := extractChain(result.LDS, "---- mitm_tls_dns_chain ----", "---- tls_chain ----")
+	if dnsChain == "" {
+		t.Fatal("mitm_tls_dns_chain not found in LDS")
+	}
+	assertContains(t, dnsChain, "envoy.filters.http.rbac",
+		"MITM chain must carry shadow RBAC for catch-all audit rule")
+	assertContains(t, dnsChain, "shadow_rules",
+		"MITM chain RBAC must be shadow_rules (audit, non-blocking)")
+	assertContains(t, dnsChain, "access_log",
+		"MITM chain must emit access_log so audit records are written")
+	assertContains(t, dnsChain, "any: true",
+		"catch-all host must produce a match-any rule inside MITM chain")
+	assertNotContains(t, dnsChain, `exact: "*"`,
+		"catch-all host must not become a literal exact:\"*\" matcher")
+}
+
+// extractChain returns the substring of lds between the start marker
+// (inclusive) and the end marker (exclusive). Returns "" if start not found.
+func extractChain(lds, startMarker, endMarker string) string {
+	lines := strings.Split(lds, "\n")
+	var b strings.Builder
+	in := false
+	for _, l := range lines {
+		if strings.Contains(l, startMarker) {
+			in = true
+		}
+		if endMarker != "" && strings.Contains(l, endMarker) && !strings.Contains(l, startMarker) {
+			in = false
+		}
+		if in {
+			b.WriteString(l)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}

--- a/pkg/lsm/bpfenforcer/enforcer.go
+++ b/pkg/lsm/bpfenforcer/enforcer.go
@@ -47,26 +47,26 @@ type bpfProfile struct {
 }
 
 type BpfEnforcer struct {
-	TaskStartCh      chan varmortypes.ContainerInfo
-	TaskDeleteCh     chan varmortypes.ContainerInfo
-	TaskDeleteSyncCh chan bool
-	objs             bpfObjects
-	capableLink      link.Link
-	openFileLink     link.Link
-	pathSymlinkLink  link.Link
-	pathLinkLink     link.Link
-	pathRenameLink   link.Link
-	bprmLink         link.Link
-	sockConnLink     link.Link
-	socketLink       link.Link
-	ptraceLink       link.Link
-	mountLink        link.Link
-	moveMountLink    link.Link
+	TaskStartCh       chan varmortypes.ContainerInfo
+	TaskDeleteCh      chan varmortypes.ContainerInfo
+	TaskDeleteSyncCh  chan bool
+	objs              bpfObjects
+	capableLink       link.Link
+	openFileLink      link.Link
+	pathSymlinkLink   link.Link
+	pathLinkLink      link.Link
+	pathRenameLink    link.Link
+	bprmLink          link.Link
+	sockConnLink      link.Link
+	socketLink        link.Link
+	ptraceLink        link.Link
+	mountLink         link.Link
+	moveMountLink     link.Link
 	umountLink        link.Link
 	maxMountRuleCount uint32
 	bpfProfileCache   map[string]bpfProfile // <profileName: bpfProfile>
-	containerCache   map[string]enforceID  // global cache <containerID: enforceID>
-	log              logr.Logger
+	containerCache    map[string]enforceID  // global cache <containerID: enforceID>
+	log               logr.Logger
 }
 
 // NewBpfEnforcer creates a BpfEnforcer, and initialize the BPF settings and resources


### PR DESCRIPTION
## Summary
Fix a bug where egress `httpRule` hosts `["*"]` (catch-all) were translated into literal `exact: "*"` string matchers instead of Envoy's `any: true` matcher. This caused catch-all rules to silently match nothing, producing no enforcement or audit records for both plaintext HTTP and TLS traffic.

The defect affected three independent code paths:
1. **TLS SNI matcher** (`httpRuleToSNIPermissions`): emitted `requested_server_name: {exact: "*"}`, which never matches real SNI values.
2. **HTTP :authority matcher** (`authorityMatcherForHostPort`, `portAgnosticHostRules`): emitted exact/prefix matchers on `"*"`, which never match real `:authority` values.
3. **MITM chain rule scoping** (`filterHTTPRulesForDomains`): dropped `"*"` rules from MITM chains because `"*"` was not in the MITM domain set, so MITM-terminated TLS traffic produced no audit records.

## Fix
- Add `isMatchAllHost()` helper to distinguish `"*"` from suffix wildcards like `"*.example.com"`.
- Special-case `"*"` before suffix/exact branches in SNI and authority matcher generation, emitting `PermissionRule{Type: "any", Value: true}`.
- Preserve `"*"` hosts in `filterHTTPRulesForDomains` so catch-all rules survive onto every MITM chain; downstream matchers correctly render them as match-any.
- Explicit ports on `"*"` rules are still enforced via the separate `destination_port` rule.

## Tests
- `TestWildcardHostMatchAll`: verifies `any: true` and no literal `exact: "*"` for allow/deny defaults and audit variants.
- `TestWildcardHostMatchAllWithPort`: verifies port binding via `destination_port` while authority matches any.
- `TestMITMWildcardHostAudit`: verifies MITM chains carry shadow RBAC + access_log for catch-all audit rules.

Also includes a minor `gofmt` alignment fix in `pkg/lsm/bpfenforcer/enforcer.go`.

## Impact
Restores the intended behavior of `defaultAction: allow` + `qualifiers: [audit]` + `hosts: ["*"]` for domain discovery, and ensures catch-all allow/deny rules correctly match all egress HTTP/HTTPS traffic.