### PR TITLE
feat(auditor): inject policy identity into violation events

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -400,12 +400,38 @@ func (agent *Agent) selectEnforcer(ap *varmor.ArmorProfile) (varmortypes.Enforce
 	return e, nil
 }
 
+// policyIdentityFromArmorProfile derives the authoritative identity of the
+// VarmorPolicy or VarmorClusterPolicy that owns the given ArmorProfile. The
+// identity is read from the ArmorProfile's controller OwnerReference (set when
+// the manager creates the ArmorProfile) rather than by string-parsing the
+// profile name, which is ambiguous because both namespace and name may contain
+// "-". For a cluster-scoped VarmorClusterPolicy the policy namespace is left
+// empty, because an ArmorProfile owned by a cluster policy carries the vArmor
+// install namespace, not a policy namespace. It is a pure function so it can be
+// unit-tested in isolation and keeps the auditor free of internal dependencies.
+func policyIdentityFromArmorProfile(ap *varmor.ArmorProfile) varmorauditor.PolicyIdentity {
+	id := varmorauditor.PolicyIdentity{}
+	if len(ap.OwnerReferences) > 0 {
+		owner := ap.OwnerReferences[0]
+		id.Kind = owner.Kind
+		id.Name = owner.Name
+	}
+	if id.Kind == "VarmorPolicy" {
+		id.Namespace = ap.Namespace
+	}
+	return id
+}
+
 // handleCreateOrUpdateArmorProfile load or reload AppArmor Profile for containers.
 func (agent *Agent) handleCreateOrUpdateArmorProfile(ap *varmor.ArmorProfile, key string) error {
 	logger := agent.log.WithName("handleCreateOrUpdateArmorProfile()")
 
 	logger.Info("ArmorProfile created or updated", "namespace", ap.Namespace, "name", ap.Name,
 		"labels", ap.Labels, "profile name", ap.Spec.Profile.Name, "profile mode", ap.Spec.Profile.Mode)
+
+	// Register the authoritative policy identity so the auditor can attribute
+	// violation events (keyed by the profile name) to the owning policy.
+	agent.auditor.UpsertPolicyIdentity(ap.Name, policyIdentityFromArmorProfile(ap))
 
 	defer func() {
 		if !agent.bpfLsmSupported || agent.existingApCount <= agent.processedApCount {
@@ -533,6 +559,9 @@ func (agent *Agent) handleDeleteArmorProfile(namespace, name, key string) error 
 	logger := agent.log.WithName("handleDeleteArmorProfile()")
 
 	logger.Info("ArmorProfile deleted", "namespace", namespace, "name", name)
+
+	// Drop the policy identity registered for this profile name.
+	agent.auditor.DeletePolicyIdentity(name)
 
 	if !agent.appArmorSupported && !agent.bpfLsmSupported {
 		return nil

--- a/internal/agent/policy_identity_test.go
+++ b/internal/agent/policy_identity_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
+	varmorauditor "github.com/bytedance/vArmor/pkg/auditor"
+)
+
+func TestPolicyIdentityFromArmorProfile(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ap       *varmor.ArmorProfile
+		expected varmorauditor.PolicyIdentity
+	}{
+		{
+			name: "namespaced VarmorPolicy keeps its namespace",
+			ap: &varmor.ArmorProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "varmor-default-demo",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "VarmorPolicy", Name: "demo"},
+					},
+				},
+			},
+			expected: varmorauditor.PolicyIdentity{
+				Kind:      "VarmorPolicy",
+				Name:      "demo",
+				Namespace: "default",
+			},
+		},
+		{
+			name: "cluster VarmorClusterPolicy drops the install namespace",
+			ap: &varmor.ArmorProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "varmor-cluster-varmor-demo",
+					Namespace: "varmor",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "VarmorClusterPolicy", Name: "demo"},
+					},
+				},
+			},
+			expected: varmorauditor.PolicyIdentity{
+				Kind:      "VarmorClusterPolicy",
+				Name:      "demo",
+				Namespace: "",
+			},
+		},
+		{
+			name: "missing OwnerReference yields an empty identity",
+			ap: &varmor.ArmorProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "varmor-default-orphan",
+					Namespace: "default",
+				},
+			},
+			expected: varmorauditor.PolicyIdentity{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := policyIdentityFromArmorProfile(tc.ap)
+			assert.Equal(t, got.Kind, tc.expected.Kind)
+			assert.Equal(t, got.Name, tc.expected.Name)
+			assert.Equal(t, got.Namespace, tc.expected.Namespace)
+		})
+	}
+}

--- a/internal/networkproxy/c4_bootstrap_test.go
+++ b/internal/networkproxy/c4_bootstrap_test.go
@@ -23,8 +23,8 @@ import (
 
 	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
 	varmorconfig "github.com/bytedance/vArmor/internal/config"
-	"github.com/bytedance/vArmor/internal/networkproxy/profile"
 	varmorprofile "github.com/bytedance/vArmor/internal/profile"
+	als "github.com/bytedance/vArmor/pkg/networkproxy/als"
 )
 
 // newNetworkProxyPolicy builds a minimal namespace-scoped AlwaysAllow
@@ -118,8 +118,8 @@ func TestGenerateEnvoySecret_AllowAllNoALSLogName(t *testing.T) {
 	}
 	lds := secret.StringData[SecretKeyLDS]
 	for _, denied := range []string{
-		fmt.Sprintf("%s:%s", profile.LogNameClassDeny, profileName),
-		fmt.Sprintf("%s:%s", profile.LogNameClassAudit, profileName),
+		fmt.Sprintf("%s:%s", als.LogNameClassDeny, profileName),
+		fmt.Sprintf("%s:%s", als.LogNameClassAudit, profileName),
 	} {
 		if strings.Contains(lds, denied) {
 			t.Errorf("allow-all listener unexpectedly emitted log_name %q", denied)

--- a/internal/networkproxy/profile/als_render_test.go
+++ b/internal/networkproxy/profile/als_render_test.go
@@ -20,6 +20,7 @@ import (
 
 	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
 	varmorconfig "github.com/bytedance/vArmor/internal/config"
+	als "github.com/bytedance/vArmor/pkg/networkproxy/als"
 )
 
 // alsFixtureEgress builds a deny-default egress that exercises all four
@@ -98,7 +99,7 @@ func TestAuditSink_GRPCALS_ListenerAndHCM(t *testing.T) {
 	}
 
 	// Every ALS entry must dial the shared cluster name (4 entries total).
-	if c := strings.Count(lds, "cluster_name: "+DefaultALSClusterName); c != 4 {
+	if c := strings.Count(lds, "cluster_name: "+als.DefaultALSClusterName); c != 4 {
 		t.Errorf("expected 4 envoy_grpc cluster_name references, got %d", c)
 	}
 
@@ -114,7 +115,7 @@ func TestAuditSink_GRPCALS_ListenerAndHCM(t *testing.T) {
 
 	// CDS must carry the STATIC UDS ALS cluster.
 	for _, want := range []string{
-		"name: " + DefaultALSClusterName,
+		"name: " + als.DefaultALSClusterName,
 		"type: STATIC",
 		"connect_timeout: 1s",
 		"lb_policy: ROUND_ROBIN",
@@ -146,7 +147,7 @@ func TestAuditSink_CustomClusterName(t *testing.T) {
 	if !strings.Contains(cds, "name: custom_als") {
 		t.Errorf("expected custom cluster in CDS")
 	}
-	if strings.Contains(cds, "name: "+DefaultALSClusterName) {
+	if strings.Contains(cds, "name: "+als.DefaultALSClusterName) {
 		t.Errorf("default ALS cluster name must not appear when overridden")
 	}
 }
@@ -161,7 +162,7 @@ func TestAuditSink_AllowAll_EmitsALSCluster(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateAllowAllEgressRules: %v", err)
 	}
-	if !strings.Contains(cds, "name: "+DefaultALSClusterName) {
+	if !strings.Contains(cds, "name: "+als.DefaultALSClusterName) {
 		t.Errorf("allow-all CDS missing ALS cluster")
 	}
 }
@@ -174,7 +175,7 @@ func TestAuditSink_DenyAll_EmitsALSCluster(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateDenyAllEgressRules: %v", err)
 	}
-	if !strings.Contains(cds, "name: "+DefaultALSClusterName) {
+	if !strings.Contains(cds, "name: "+als.DefaultALSClusterName) {
 		t.Errorf("deny-all CDS missing ALS cluster under grpc_als")
 	}
 }
@@ -199,7 +200,7 @@ func TestAuditSink_GRPCALS_MITMChain(t *testing.T) {
 	lds, _ := renderALSAudit(t, mitm, audit)
 
 	// The MITM chain must be present.
-	if !strings.Contains(lds, FilterChainNameMITMTLSDNS) {
+	if !strings.Contains(lds, als.FilterChainNameMITMTLSDNS) {
 		t.Fatalf("expected MITM filter chain in LDS")
 	}
 	// No stdout sink may survive anywhere, including the MITM HCM.
@@ -210,8 +211,8 @@ func TestAuditSink_GRPCALS_MITMChain(t *testing.T) {
 	if !strings.Contains(lds, "access_loggers.grpc.v3.HttpGrpcAccessLogConfig") {
 		t.Errorf("expected HttpGrpcAccessLogConfig (L7) in MITM LDS")
 	}
-	if !strings.Contains(lds, "cluster_name: "+DefaultALSClusterName) {
-		t.Errorf("expected MITM access_log to dial %s", DefaultALSClusterName)
+	if !strings.Contains(lds, "cluster_name: "+als.DefaultALSClusterName) {
+		t.Errorf("expected MITM access_log to dial %s", als.DefaultALSClusterName)
 	}
 }
 
@@ -233,11 +234,11 @@ func TestAuditSink_GRPCALS_FilterChainCustomTag(t *testing.T) {
 
 	// L7 chains each get a filter_chain literal custom_tag. http_chain and
 	// mitm_tls_dns_chain are both present in this fixture.
-	wantTag := "- tag: " + ALSFilterChainTagKey
+	wantTag := "- tag: " + als.ALSFilterChainTagKey
 	if !strings.Contains(lds, wantTag) {
 		t.Fatalf("expected filter_chain custom_tag in LDS, none found")
 	}
-	for _, chain := range []string{FilterChainNameHTTP, FilterChainNameMITMTLSDNS} {
+	for _, chain := range []string{als.FilterChainNameHTTP, als.FilterChainNameMITMTLSDNS} {
 		if !strings.Contains(lds, `value: "`+chain+`"`) {
 			t.Errorf("expected filter_chain custom_tag value %q in LDS", chain)
 		}
@@ -246,7 +247,7 @@ func TestAuditSink_GRPCALS_FilterChainCustomTag(t *testing.T) {
 	// The L4 listener-level access_log must NOT carry a chain tag: it is shared
 	// across tls_chain and tcp_default_chain, so a static literal cannot tell
 	// them apart. Assert no tag names an L4-only chain.
-	for _, chain := range []string{FilterChainNameTLS, FilterChainNameTCPDefault} {
+	for _, chain := range []string{als.FilterChainNameTLS, als.FilterChainNameTCPDefault} {
 		if strings.Contains(lds, `value: "`+chain+`"`) {
 			t.Errorf("L4 listener access_log must not carry a %q filter_chain tag", chain)
 		}

--- a/internal/networkproxy/profile/audit_sink.go
+++ b/internal/networkproxy/profile/audit_sink.go
@@ -14,6 +14,10 @@
 
 package profile
 
+import (
+	als "github.com/bytedance/vArmor/pkg/networkproxy/als"
+)
+
 // This file introduces the AuditSinkConfig abstraction that parameterises the
 // Envoy gRPC ALS access_log sink used for NetworkProxy violation auditing. It is
 // threaded as a parameter through the translation chain (facade -> translator ->
@@ -21,51 +25,16 @@ package profile
 // UDS endpoint without re-plumbing every signature.
 //
 // NetworkProxy violations always stream over gRPC ALS (Access Log Service) to
-// the node-local agent's auditor via a STATIC UDS cluster. The type, constants
-// and helper methods follow the shared gRPC ALS protocol so the renderer and the
-// agent's auditor stay byte-compatible.
-
-const (
-	// DefaultALSClusterName is the CDS cluster name of the gRPC ALS endpoint.
-	// It is a fixed, shared convention so the renderer and the agent's
-	// auditor stay byte-compatible.
-	DefaultALSClusterName = "varmor_audit_als"
-
-	// LogNameClassDeny / LogNameClassAudit are the two log_name classes the
-	// renderer embeds (as "<class>:<profileName>") into each gRPC ALS
-	// access_log entry. The auditor parses the class to map an event to an
-	// action: deny -> DENIED, audit -> AUDIT. This is a shared convention
-	// between the renderer and the agent's auditor.
-	LogNameClassDeny  = "varmor_np_deny"
-	LogNameClassAudit = "varmor_np_audit"
-
-	// ALSFilterChainTagKey is the gRPC ALS custom_tag key whose literal value
-	// carries the originating Envoy filter chain name (e.g. "http_chain",
-	// "mitm_tls_dns_chain"). The renderer injects it as a literal custom_tag on
-	// each L7 access_log entry; the auditor reads it back from
-	// AccessLogCommon.custom_tags to attribute the event to its chain. The L4
-	// listener-level access_log is shared across the passthrough tls_chain and
-	// tcp_default_chain, so no chain tag is emitted there.
-	ALSFilterChainTagKey = "filter_chain"
-)
-
-// Filter chain names. These are the literal values already used as the
-// FilterChain.Name throughout the translator; promoting them to constants
-// lets the HCM carry its owning chain name for the gRPC ALS custom_tag
-// without re-deriving the string in two places.
-const (
-	FilterChainNameHTTP       = "http_chain"
-	FilterChainNameMITMTLSDNS = "mitm_tls_dns_chain"
-	FilterChainNameMITMTLSIP  = "mitm_tls_ip_chain"
-	FilterChainNameTLS        = "tls_chain"
-	FilterChainNameTCPDefault = "tcp_default_chain"
-)
+// the node-local agent's auditor via a STATIC UDS cluster. The wire-level
+// constants of that protocol live in the dependency-free pkg/networkproxy/als
+// leaf package so the renderer and the agent's auditor stay byte-compatible
+// without the auditor importing any internal/ package.
 
 // AuditSinkConfig parameterises the Envoy gRPC ALS access_log sink used for
 // NetworkProxy violation auditing.
 type AuditSinkConfig struct {
 	// ALSClusterName is the CDS cluster name for the gRPC ALS endpoint.
-	// Defaults to DefaultALSClusterName when empty.
+	// Defaults to als.DefaultALSClusterName when empty.
 	ALSClusterName string
 	// ALSUDSPath is the UDS pipe path (inside the sidecar) the ALS cluster
 	// dials.
@@ -91,17 +60,17 @@ func (a AuditSinkConfig) clusterName() string {
 	if a.ALSClusterName != "" {
 		return a.ALSClusterName
 	}
-	return DefaultALSClusterName
+	return als.DefaultALSClusterName
 }
 
 // denyLogName returns the log_name embedded into the deny access_log entry,
-// encoded as "<LogNameClassDeny>:<ProfileName>".
+// encoded as "<als.LogNameClassDeny>:<ProfileName>".
 func (a AuditSinkConfig) denyLogName() string {
-	return LogNameClassDeny + ":" + a.ProfileName
+	return als.LogNameClassDeny + ":" + a.ProfileName
 }
 
 // auditLogName returns the log_name embedded into the shadow/audit access_log
-// entry, encoded as "<LogNameClassAudit>:<ProfileName>".
+// entry, encoded as "<als.LogNameClassAudit>:<ProfileName>".
 func (a AuditSinkConfig) auditLogName() string {
-	return LogNameClassAudit + ":" + a.ProfileName
+	return als.LogNameClassAudit + ":" + a.ProfileName
 }

--- a/internal/networkproxy/profile/audit_sink_test.go
+++ b/internal/networkproxy/profile/audit_sink_test.go
@@ -14,7 +14,11 @@
 
 package profile
 
-import "testing"
+import (
+	"testing"
+
+	als "github.com/bytedance/vArmor/pkg/networkproxy/als"
+)
 
 func TestAuditSinkConfig_ClusterName(t *testing.T) {
 	tests := []struct {
@@ -22,7 +26,7 @@ func TestAuditSinkConfig_ClusterName(t *testing.T) {
 		cfg  AuditSinkConfig
 		want string
 	}{
-		{"empty defaults", AuditSinkConfig{}, DefaultALSClusterName},
+		{"empty defaults", AuditSinkConfig{}, als.DefaultALSClusterName},
 		{"override", AuditSinkConfig{ALSClusterName: "custom_als"}, "custom_als"},
 	}
 	for _, tt := range tests {
@@ -36,36 +40,19 @@ func TestAuditSinkConfig_ClusterName(t *testing.T) {
 
 func TestAuditSinkConfig_LogNames(t *testing.T) {
 	cfg := AuditSinkConfig{ProfileName: "my-profile"}
-	if got, want := cfg.denyLogName(), LogNameClassDeny+":my-profile"; got != want {
+	if got, want := cfg.denyLogName(), als.LogNameClassDeny+":my-profile"; got != want {
 		t.Errorf("denyLogName() = %q, want %q", got, want)
 	}
-	if got, want := cfg.auditLogName(), LogNameClassAudit+":my-profile"; got != want {
+	if got, want := cfg.auditLogName(), als.LogNameClassAudit+":my-profile"; got != want {
 		t.Errorf("auditLogName() = %q, want %q", got, want)
 	}
 
 	// Empty profile name still yields a well-formed "<class>:" prefix.
 	empty := AuditSinkConfig{}
-	if got, want := empty.denyLogName(), LogNameClassDeny+":"; got != want {
+	if got, want := empty.denyLogName(), als.LogNameClassDeny+":"; got != want {
 		t.Errorf("denyLogName() empty = %q, want %q", got, want)
 	}
-	if got, want := empty.auditLogName(), LogNameClassAudit+":"; got != want {
+	if got, want := empty.auditLogName(), als.LogNameClassAudit+":"; got != want {
 		t.Errorf("auditLogName() empty = %q, want %q", got, want)
-	}
-}
-
-// TestAuditSinkConfig_SharedConstants pins the wire-level constants that MUST
-// stay byte-compatible across the shared gRPC ALS protocol. A change here is
-// a protocol break.
-func TestAuditSinkConfig_SharedConstants(t *testing.T) {
-	cases := map[string]string{
-		DefaultALSClusterName: "varmor_audit_als",
-		LogNameClassDeny:      "varmor_np_deny",
-		LogNameClassAudit:     "varmor_np_audit",
-		ALSFilterChainTagKey:  "filter_chain",
-	}
-	for got, want := range cases {
-		if got != want {
-			t.Errorf("shared constant = %q, want %q", got, want)
-		}
 	}
 }

--- a/internal/networkproxy/profile/renderer.go
+++ b/internal/networkproxy/profile/renderer.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	varmorconfig "github.com/bytedance/vArmor/internal/config"
+	als "github.com/bytedance/vArmor/pkg/networkproxy/als"
 )
 
 // ============================================================================
@@ -853,7 +854,7 @@ func renderALSAccessLogEntry(sb *strings.Builder, itemPrefix, celExpr, logName, 
 	}
 	if filterChain != "" {
 		sb.WriteString(b + "    custom_tags:\n")
-		sb.WriteString(b + "    - tag: " + ALSFilterChainTagKey + "\n")
+		sb.WriteString(b + "    - tag: " + als.ALSFilterChainTagKey + "\n")
 		sb.WriteString(b + "      literal:\n")
 		sb.WriteString(b + "        value: \"" + yamlEscapeScalar(filterChain) + "\"\n")
 	}

--- a/internal/networkproxy/profile/translator.go
+++ b/internal/networkproxy/profile/translator.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
+	als "github.com/bytedance/vArmor/pkg/networkproxy/als"
 )
 
 // ============================================================================
@@ -455,7 +456,7 @@ func buildTLSChain(defaultDeny bool,
 	auditCfg AuditConfig,
 ) FilterChain {
 	chain := FilterChain{
-		Name: FilterChainNameTLS,
+		Name: als.FilterChainNameTLS,
 		FilterChainMatch: &FilterChainMatch{
 			TransportProtocol: "tls",
 		},
@@ -602,7 +603,7 @@ func buildHTTPChain(defaultDeny bool,
 	auditCfg AuditConfig, audit AuditSinkConfig,
 ) FilterChain {
 	chain := FilterChain{
-		Name: FilterChainNameHTTP,
+		Name: als.FilterChainNameHTTP,
 		FilterChainMatch: &FilterChainMatch{
 			ApplicationProtocols: []string{"http/1.0", "http/1.1", "h2c"},
 		},
@@ -669,7 +670,7 @@ func buildHTTPChain(defaultDeny bool,
 			AccessLogDenyCEL:   hcmDenyCEL,
 			AccessLogShadowCEL: hcmShadowCEL,
 			AuditSink:          audit,
-			FilterChainName:    FilterChainNameHTTP,
+			FilterChainName:    als.FilterChainNameHTTP,
 			RouteConfig: &RouteConfig{
 				Name: "local_route",
 				VirtualHosts: []VirtualHost{{
@@ -734,7 +735,7 @@ func buildTCPDefaultChain(defaultDeny bool,
 	auditCfg AuditConfig,
 ) FilterChain {
 	chain := FilterChain{
-		Name:             FilterChainNameTCPDefault,
+		Name:             als.FilterChainNameTCPDefault,
 		FilterChainMatch: nil,
 	}
 

--- a/internal/networkproxy/profile/translator_mitm.go
+++ b/internal/networkproxy/profile/translator_mitm.go
@@ -57,6 +57,7 @@ import (
 
 	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
 	varmorconfig "github.com/bytedance/vArmor/internal/config"
+	als "github.com/bytedance/vArmor/pkg/networkproxy/als"
 )
 
 // ============================================================================
@@ -361,9 +362,9 @@ func buildMITMChains(cls egressClassification, mitm *MITMInput, audit AuditSinkC
 
 	var chains []FilterChain
 	if len(dnsNames) > 0 {
-		dnsHCM := buildMITMHCMFilter(cls, dnsNames, mitm.HeadersByDomain, audit, FilterChainNameMITMTLSDNS)
+		dnsHCM := buildMITMHCMFilter(cls, dnsNames, mitm.HeadersByDomain, audit, als.FilterChainNameMITMTLSDNS)
 		chains = append(chains, FilterChain{
-			Name: FilterChainNameMITMTLSDNS,
+			Name: als.FilterChainNameMITMTLSDNS,
 			FilterChainMatch: &FilterChainMatch{
 				TransportProtocol: "tls",
 				ServerNames:       dnsNames,
@@ -373,9 +374,9 @@ func buildMITMChains(cls egressClassification, mitm *MITMInput, audit AuditSinkC
 		})
 	}
 	if len(ipPrefixes) > 0 {
-		ipHCM := buildMITMHCMFilter(cls, ipPrefixes, mitm.HeadersByDomain, audit, FilterChainNameMITMTLSIP)
+		ipHCM := buildMITMHCMFilter(cls, ipPrefixes, mitm.HeadersByDomain, audit, als.FilterChainNameMITMTLSIP)
 		chains = append(chains, FilterChain{
-			Name: FilterChainNameMITMTLSIP,
+			Name: als.FilterChainNameMITMTLSIP,
 			FilterChainMatch: &FilterChainMatch{
 				TransportProtocol: "tls",
 				PrefixRanges:      ipPrefixes,

--- a/pkg/auditor/als.go
+++ b/pkg/auditor/als.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	varmorprofile "github.com/bytedance/vArmor/internal/networkproxy/profile"
+	als "github.com/bytedance/vArmor/pkg/networkproxy/als"
 )
 
 // alsGracefulStopTimeout bounds how long closeALSConsumer waits for the ALS
@@ -112,9 +112,9 @@ func parseLogName(logName string) (action, profileName string, ok bool) {
 		return "", "", false
 	}
 	switch class {
-	case varmorprofile.LogNameClassDeny:
+	case als.LogNameClassDeny:
 		return actionDenied, profileName, true
-	case varmorprofile.LogNameClassAudit:
+	case als.LogNameClassAudit:
 		return actionAudit, profileName, true
 	default:
 		return "", "", false
@@ -286,7 +286,7 @@ func buildHTTPNetworkProxyEvent(e *dataaccesslogv3.HTTPAccessLogEntry) (NetworkP
 // shared across the passthrough chains and never carries it, so this returns ""
 // for them.
 func filterChainTag(c *dataaccesslogv3.AccessLogCommon) string {
-	return c.GetCustomTags()[varmorprofile.ALSFilterChainTagKey]
+	return c.GetCustomTags()[als.ALSFilterChainTagKey]
 }
 
 func accessLogStartTime(c *dataaccesslogv3.AccessLogCommon) time.Time {

--- a/pkg/auditor/als.go
+++ b/pkg/auditor/als.go
@@ -242,6 +242,7 @@ func (auditor *Auditor) recordNetworkProxyViolation(action, profileName string, 
 		Str("enforcer", enforcerNetworkProxy).
 		Str("action", action).
 		Str("profileName", profileName).
+		Func(auditor.withPolicyIdentity(profileName)).
 		Interface("event", event).Msg("violation event")
 }
 

--- a/pkg/auditor/als_test.go
+++ b/pkg/auditor/als_test.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	varmorprofile "github.com/bytedance/vArmor/internal/networkproxy/profile"
+	als "github.com/bytedance/vArmor/pkg/networkproxy/als"
 )
 
 var (
@@ -101,21 +101,21 @@ func TestParseLogName(t *testing.T) {
 	}{
 		{
 			name:        "deny",
-			logName:     varmorprofile.LogNameClassDeny + ":profile-a",
+			logName:     als.LogNameClassDeny + ":profile-a",
 			wantAction:  actionDenied,
 			wantProfile: "profile-a",
 			wantOK:      true,
 		},
 		{
 			name:        "audit",
-			logName:     varmorprofile.LogNameClassAudit + ":profile-b",
+			logName:     als.LogNameClassAudit + ":profile-b",
 			wantAction:  actionAudit,
 			wantProfile: "profile-b",
 			wantOK:      true,
 		},
 		{name: "unknown class", logName: "unknown:profile", wantOK: false},
 		{name: "missing separator", logName: "profile", wantOK: false},
-		{name: "empty profile", logName: varmorprofile.LogNameClassDeny + ":", wantOK: false},
+		{name: "empty profile", logName: als.LogNameClassDeny + ":", wantOK: false},
 	}
 
 	for _, tt := range tests {
@@ -138,7 +138,7 @@ func TestALSStreamAccessLogsEmitsNetworkProxyEvents(t *testing.T) {
 		messages: []*accesslogv3.StreamAccessLogsMessage{
 			{
 				Identifier: &accesslogv3.StreamAccessLogsMessage_Identifier{
-					LogName: varmorprofile.LogNameClassDeny + ":profile-a",
+					LogName: als.LogNameClassDeny + ":profile-a",
 					Node:    podNode("workload-a", "team-x", "uid-123"),
 				},
 				LogEntries: &accesslogv3.StreamAccessLogsMessage_TcpLogs{
@@ -227,7 +227,7 @@ func TestALSStreamAccessLogsAuditAction(t *testing.T) {
 		ctx: context.Background(),
 		messages: []*accesslogv3.StreamAccessLogsMessage{{
 			Identifier: &accesslogv3.StreamAccessLogsMessage_Identifier{
-				LogName: varmorprofile.LogNameClassAudit + ":profile-b",
+				LogName: als.LogNameClassAudit + ":profile-b",
 			},
 			LogEntries: &accesslogv3.StreamAccessLogsMessage_HttpLogs{
 				HttpLogs: &accesslogv3.StreamAccessLogsMessage_HTTPAccessLogEntries{
@@ -336,12 +336,12 @@ func TestFilterChainTagOnlyOnL7(t *testing.T) {
 	// no tag. Verify the HTTP builder surfaces it and the TCP builder omits it.
 	httpEntry := &dataaccesslogv3.HTTPAccessLogEntry{
 		CommonProperties: &dataaccesslogv3.AccessLogCommon{
-			CustomTags: map[string]string{varmorprofile.ALSFilterChainTagKey: varmorprofile.FilterChainNameHTTP},
+			CustomTags: map[string]string{als.ALSFilterChainTagKey: als.FilterChainNameHTTP},
 		},
 	}
 	httpEvent, _ := buildHTTPNetworkProxyEvent(httpEntry)
-	if httpEvent.FilterChain != varmorprofile.FilterChainNameHTTP {
-		t.Fatalf("HTTP filterChain = %q, want %q", httpEvent.FilterChain, varmorprofile.FilterChainNameHTTP)
+	if httpEvent.FilterChain != als.FilterChainNameHTTP {
+		t.Fatalf("HTTP filterChain = %q, want %q", httpEvent.FilterChain, als.FilterChainNameHTTP)
 	}
 
 	tcpEntry := &dataaccesslogv3.TCPAccessLogEntry{
@@ -480,7 +480,7 @@ func TestStartAndCloseALSConsumerLifecycle(t *testing.T) {
 	}
 	if err := stream.Send(&accesslogv3.StreamAccessLogsMessage{
 		Identifier: &accesslogv3.StreamAccessLogsMessage_Identifier{
-			LogName: varmorprofile.LogNameClassDeny + ":profile-a",
+			LogName: als.LogNameClassDeny + ":profile-a",
 		},
 	}); err != nil {
 		t.Fatalf("stream.Send() error = %v", err)

--- a/pkg/auditor/als_test.go
+++ b/pkg/auditor/als_test.go
@@ -49,16 +49,19 @@ var (
 // violationLogger. Only the fields the NetworkProxy collector populates are
 // declared; the rest are ignored by the JSON decoder.
 type recordedViolation struct {
-	NodeName       string            `json:"nodeName"`
-	PodName        string            `json:"podName"`
-	PodNamespace   string            `json:"podNamespace"`
-	PodUID         string            `json:"podUID"`
-	ContainerID    string            `json:"containerID"`
-	Enforcer       string            `json:"enforcer"`
-	Action         string            `json:"action"`
-	ProfileName    string            `json:"profileName"`
-	EventTimestamp uint64            `json:"eventTimestamp"`
-	Event          NetworkProxyEvent `json:"event"`
+	NodeName        string            `json:"nodeName"`
+	PodName         string            `json:"podName"`
+	PodNamespace    string            `json:"podNamespace"`
+	PodUID          string            `json:"podUID"`
+	ContainerID     string            `json:"containerID"`
+	Enforcer        string            `json:"enforcer"`
+	Action          string            `json:"action"`
+	ProfileName     string            `json:"profileName"`
+	PolicyKind      string            `json:"policyKind"`
+	PolicyName      string            `json:"policyName"`
+	PolicyNamespace string            `json:"policyNamespace"`
+	EventTimestamp  uint64            `json:"eventTimestamp"`
+	Event           NetworkProxyEvent `json:"event"`
 }
 
 // newTestAuditor builds an Auditor whose violationLogger writes JSON lines to
@@ -66,10 +69,11 @@ type recordedViolation struct {
 // ALS path can be exercised in isolation.
 func newTestAuditor(buf *bytes.Buffer) *Auditor {
 	return &Auditor{
-		nodeName:           "node-a",
-		auditEventMetadata: map[string]interface{}{"cluster": "test"},
-		violationLogger:    zerolog.New(buf).With().Timestamp().Logger(),
-		log:                logr.Discard(),
+		nodeName:            "node-a",
+		auditEventMetadata:  map[string]interface{}{"cluster": "test"},
+		violationLogger:     zerolog.New(buf).With().Timestamp().Logger(),
+		policyIdentityCache: make(map[string]PolicyIdentity),
+		log:                 logr.Discard(),
 	}
 }
 
@@ -513,4 +517,77 @@ func TestStartALSConsumerNoopWhenSocketPathEmpty(t *testing.T) {
 	}
 	// closeALSConsumer must be safe to call when nothing was started.
 	a.closeALSConsumer()
+}
+
+// TestALSStreamAccessLogsPolicyIdentity verifies the NetworkProxy emission path
+// embeds the policyKind/policyName/policyNamespace fields looked up from the
+// identity cache, and falls back to empty fields on a cache miss.
+func TestALSStreamAccessLogsPolicyIdentity(t *testing.T) {
+	t.Run("hit", func(t *testing.T) {
+		var buf bytes.Buffer
+		a := newTestAuditor(&buf)
+		a.UpsertPolicyIdentity("profile-a", PolicyIdentity{
+			Kind: "VarmorPolicy", Name: "nginx", Namespace: "demo",
+		})
+		stream := &fakeALSStream{
+			ctx: context.Background(),
+			messages: []*accesslogv3.StreamAccessLogsMessage{{
+				Identifier: &accesslogv3.StreamAccessLogsMessage_Identifier{
+					LogName: als.LogNameClassDeny + ":profile-a",
+				},
+				LogEntries: &accesslogv3.StreamAccessLogsMessage_HttpLogs{
+					HttpLogs: &accesslogv3.StreamAccessLogsMessage_HTTPAccessLogEntries{
+						LogEntry: []*dataaccesslogv3.HTTPAccessLogEntry{{}},
+					},
+				},
+			}},
+		}
+		if err := (&alsServer{auditor: a}).StreamAccessLogs(stream); err != nil {
+			t.Fatalf("StreamAccessLogs() error = %v", err)
+		}
+		events := decodeViolations(t, &buf)
+		if len(events) != 1 {
+			t.Fatalf("emitted %d events, want 1", len(events))
+		}
+		ev := events[0]
+		if ev.PolicyKind != "VarmorPolicy" || ev.PolicyName != "nginx" || ev.PolicyNamespace != "demo" {
+			t.Fatalf("policy identity = (%q, %q, %q), want (VarmorPolicy, nginx, demo)",
+				ev.PolicyKind, ev.PolicyName, ev.PolicyNamespace)
+		}
+	})
+
+	t.Run("miss emits empty fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		a := newTestAuditor(&buf)
+		// No identity registered for profile-a.
+		stream := &fakeALSStream{
+			ctx: context.Background(),
+			messages: []*accesslogv3.StreamAccessLogsMessage{{
+				Identifier: &accesslogv3.StreamAccessLogsMessage_Identifier{
+					LogName: als.LogNameClassDeny + ":profile-a",
+				},
+				LogEntries: &accesslogv3.StreamAccessLogsMessage_HttpLogs{
+					HttpLogs: &accesslogv3.StreamAccessLogsMessage_HTTPAccessLogEntries{
+						LogEntry: []*dataaccesslogv3.HTTPAccessLogEntry{{}},
+					},
+				},
+			}},
+		}
+		if err := (&alsServer{auditor: a}).StreamAccessLogs(stream); err != nil {
+			t.Fatalf("StreamAccessLogs() error = %v", err)
+		}
+		events := decodeViolations(t, &buf)
+		if len(events) != 1 {
+			t.Fatalf("emitted %d events, want 1", len(events))
+		}
+		ev := events[0]
+		if ev.PolicyKind != "" || ev.PolicyName != "" || ev.PolicyNamespace != "" {
+			t.Fatalf("policy identity on miss = (%q, %q, %q), want all empty",
+				ev.PolicyKind, ev.PolicyName, ev.PolicyNamespace)
+		}
+		// profileName must still be present so downstream can attribute later.
+		if ev.ProfileName != "profile-a" {
+			t.Fatalf("profileName = %q, want profile-a", ev.ProfileName)
+		}
+	})
 }

--- a/pkg/auditor/audit.go
+++ b/pkg/auditor/audit.go
@@ -97,6 +97,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Str("enforcer", "AppArmor").
 				Str("action", "DENIED").
 				Str("profileName", profileName).
+				Func(auditor.withPolicyIdentity(profileName)).
 				Interface("event", e).Msg("violation event")
 		case AuditAction:
 			auditor.violationLogger.Warn().
@@ -114,6 +115,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Str("enforcer", "AppArmor").
 				Str("action", "AUDIT").
 				Str("profileName", profileName).
+				Func(auditor.withPolicyIdentity(profileName)).
 				Interface("event", e).Msg("violation event")
 		case AllowedAction:
 			if ch, ok := auditor.auditEventChs[profileName]; ok {
@@ -137,6 +139,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 					Str("enforcer", "AppArmor").
 					Str("action", "ALLOWED").
 					Str("profileName", profileName).
+					Func(auditor.withPolicyIdentity(profileName)).
 					Interface("event", e).Msg("violation event")
 			}
 		}
@@ -210,6 +213,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Str("enforcer", "Seccomp").
 				Str("action", "AUDIT|ALLOWED").
 				Str("profileName", profileName).
+				Func(auditor.withPolicyIdentity(profileName)).
 				Interface("event", e).Msg("violation event")
 		} else {
 			// Send the behavior event to all subscribers

--- a/pkg/auditor/auditor.go
+++ b/pkg/auditor/auditor.go
@@ -53,14 +53,20 @@ type Auditor struct {
 	TaskDeleteSyncCh       chan bool
 	mntNsIDCache           map[uint32]uint32                    // key: The init PID of contaienr, value: The mnt ns id
 	containerCache         map[uint32]varmortypes.ContainerInfo // key: The mnt ns id of container, value: The container information
-	auditEventChs          map[string]chan<- string             // auditEventChs used for sending apparmor & seccomp behavior event to subscribers, key: profile name, value: audit event channel
-	bpfEventChs            map[string]chan<- BpfEvent           // bpfEventChs used for sending bpf behavior event to subscribers, key: profile name, value: bpf event channel
-	auditLogPath           string
-	auditLogTail           *tail.Tail
-	savedRateLimit         uint64
-	auditRbMap             *ebpf.Map
-	auditEventMetadata     map[string]interface{} // auditEventMetadata used for storing additional information of the violation event
-	violationLogger        zerolog.Logger
+	// policyIdentityCache maps an ArmorProfile name to the authoritative
+	// identity of the VarmorPolicy/VarmorClusterPolicy that owns it. It is
+	// written by the agent from its ArmorProfile watch and read by every
+	// violation emission path, so it is guarded by policyIdentityMu.
+	policyIdentityCache map[string]PolicyIdentity // key: profile name
+	policyIdentityMu    sync.RWMutex
+	auditEventChs       map[string]chan<- string   // auditEventChs used for sending apparmor & seccomp behavior event to subscribers, key: profile name, value: audit event channel
+	bpfEventChs         map[string]chan<- BpfEvent // bpfEventChs used for sending bpf behavior event to subscribers, key: profile name, value: bpf event channel
+	auditLogPath        string
+	auditLogTail        *tail.Tail
+	savedRateLimit      uint64
+	auditRbMap          *ebpf.Map
+	auditEventMetadata  map[string]interface{} // auditEventMetadata used for storing additional information of the violation event
+	violationLogger     zerolog.Logger
 	// alsSocketPath is the host-side UDS path the NetworkProxy ALS gRPC
 	// server listens on. It is injected by the caller (the agent); an empty
 	// path disables the ALS collector.
@@ -85,6 +91,7 @@ func NewAuditor(nodeName string, appArmorSupported, bpfLsmSupported, enableBehav
 		TaskDeleteSyncCh:       make(chan bool, 1),
 		mntNsIDCache:           make(map[uint32]uint32, 100),
 		containerCache:         make(map[uint32]varmortypes.ContainerInfo, 100),
+		policyIdentityCache:    make(map[string]PolicyIdentity),
 		auditEventChs:          make(map[string]chan<- string),
 		bpfEventChs:            make(map[string]chan<- BpfEvent),
 		savedRateLimit:         0,

--- a/pkg/auditor/bpf.go
+++ b/pkg/auditor/bpf.go
@@ -345,6 +345,7 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 				Str("enforcer", "BPF").
 				Str("action", "DENIED").
 				Str("profileName", auditor.containerCache[eventHeader.MntNs].ProfileName).
+				Func(auditor.withPolicyIdentity(auditor.containerCache[eventHeader.MntNs].ProfileName)).
 				Interface("event", e).Msg("violation event")
 
 		case bpfenforcer.AuditAction:
@@ -364,6 +365,7 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 				Str("enforcer", "BPF").
 				Str("action", "AUDIT").
 				Str("profileName", auditor.containerCache[eventHeader.MntNs].ProfileName).
+				Func(auditor.withPolicyIdentity(auditor.containerCache[eventHeader.MntNs].ProfileName)).
 				Interface("event", e).Msg("violation event")
 
 		case bpfenforcer.AllowedAction:

--- a/pkg/auditor/policy_identity.go
+++ b/pkg/auditor/policy_identity.go
@@ -14,6 +14,10 @@
 
 package audit
 
+import (
+	"github.com/rs/zerolog"
+)
+
 // PolicyIdentity is the authoritative identity of the VarmorPolicy or
 // VarmorClusterPolicy that a violation event is attributed to. It is derived
 // from the owning ArmorProfile's metadata (never by string-parsing the profile
@@ -58,4 +62,18 @@ func (auditor *Auditor) lookupPolicyIdentity(profileName string) (PolicyIdentity
 	defer auditor.policyIdentityMu.RUnlock()
 	id, ok := auditor.policyIdentityCache[profileName]
 	return id, ok
+}
+
+// withPolicyIdentity returns a zerolog field-injector that embeds the
+// policyKind/policyName/policyNamespace fields for the given ArmorProfile name
+// into a violation event. It is chained into every emission path via
+// (*zerolog.Event).Func. On a cache miss the three fields are emitted as empty
+// strings, so attribution is best-effort and never blocks or drops an event.
+func (auditor *Auditor) withPolicyIdentity(profileName string) func(*zerolog.Event) {
+	id, _ := auditor.lookupPolicyIdentity(profileName)
+	return func(e *zerolog.Event) {
+		e.Str("policyKind", id.Kind).
+			Str("policyName", id.Name).
+			Str("policyNamespace", id.Namespace)
+	}
 }

--- a/pkg/auditor/policy_identity.go
+++ b/pkg/auditor/policy_identity.go
@@ -1,0 +1,61 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+// PolicyIdentity is the authoritative identity of the VarmorPolicy or
+// VarmorClusterPolicy that a violation event is attributed to. It is derived
+// from the owning ArmorProfile's metadata (never by string-parsing the profile
+// name, which is ambiguous because both namespace and name may contain "-"),
+// and is embedded into each violation event as the policyKind/policyName/
+// policyNamespace fields so users can immediately tell which policy caused a
+// violation.
+type PolicyIdentity struct {
+	// Kind is "VarmorPolicy" or "VarmorClusterPolicy".
+	Kind string
+	// Name is the policy's metadata.name.
+	Name string
+	// Namespace is the policy's namespace for a namespaced VarmorPolicy, and
+	// an empty string for a cluster-scoped VarmorClusterPolicy.
+	Namespace string
+}
+
+// UpsertPolicyIdentity registers or updates the authoritative identity for the
+// given ArmorProfile name. It is intended to be called by the agent from its
+// ArmorProfile watch add/update handlers. It is safe for concurrent use.
+func (auditor *Auditor) UpsertPolicyIdentity(profileName string, id PolicyIdentity) {
+	auditor.policyIdentityMu.Lock()
+	defer auditor.policyIdentityMu.Unlock()
+	auditor.policyIdentityCache[profileName] = id
+}
+
+// DeletePolicyIdentity removes the identity registered for the given
+// ArmorProfile name. It is intended to be called by the agent from its
+// ArmorProfile watch delete handler. It is safe for concurrent use.
+func (auditor *Auditor) DeletePolicyIdentity(profileName string) {
+	auditor.policyIdentityMu.Lock()
+	defer auditor.policyIdentityMu.Unlock()
+	delete(auditor.policyIdentityCache, profileName)
+}
+
+// lookupPolicyIdentity returns the identity registered for the given
+// ArmorProfile name. The boolean result reports whether an entry was found;
+// callers treat a miss as best-effort and emit empty policy fields. It is safe
+// for concurrent use.
+func (auditor *Auditor) lookupPolicyIdentity(profileName string) (PolicyIdentity, bool) {
+	auditor.policyIdentityMu.RLock()
+	defer auditor.policyIdentityMu.RUnlock()
+	id, ok := auditor.policyIdentityCache[profileName]
+	return id, ok
+}

--- a/pkg/auditor/policy_identity_test.go
+++ b/pkg/auditor/policy_identity_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"sync"
+	"testing"
+)
+
+// newIdentityTestAuditor returns a minimal Auditor with only the policy
+// identity cache initialised, so the identity API can be exercised without the
+// full NewAuditor construction (which requires host state such as audit log
+// files).
+func newIdentityTestAuditor() *Auditor {
+	return &Auditor{
+		policyIdentityCache: make(map[string]PolicyIdentity),
+	}
+}
+
+func TestPolicyIdentityUpsertLookupDelete(t *testing.T) {
+	auditor := newIdentityTestAuditor()
+
+	// Miss on an unknown profile yields a zero value and ok=false.
+	if id, ok := auditor.lookupPolicyIdentity("varmor-demo-nginx"); ok || id != (PolicyIdentity{}) {
+		t.Fatalf("expected miss for unknown profile, got id=%+v ok=%v", id, ok)
+	}
+
+	// Upsert a namespaced VarmorPolicy identity.
+	ns := PolicyIdentity{Kind: "VarmorPolicy", Name: "nginx", Namespace: "demo"}
+	auditor.UpsertPolicyIdentity("varmor-demo-nginx", ns)
+	if id, ok := auditor.lookupPolicyIdentity("varmor-demo-nginx"); !ok || id != ns {
+		t.Fatalf("expected namespaced identity %+v, got id=%+v ok=%v", ns, id, ok)
+	}
+
+	// Upsert overwrites the existing entry.
+	updated := PolicyIdentity{Kind: "VarmorPolicy", Name: "nginx", Namespace: "demo2"}
+	auditor.UpsertPolicyIdentity("varmor-demo-nginx", updated)
+	if id, _ := auditor.lookupPolicyIdentity("varmor-demo-nginx"); id != updated {
+		t.Fatalf("expected upsert to overwrite, got %+v", id)
+	}
+
+	// Cluster-scoped identity carries an empty namespace.
+	cluster := PolicyIdentity{Kind: "VarmorClusterPolicy", Name: "block-exec", Namespace: ""}
+	auditor.UpsertPolicyIdentity("varmor-cluster-varmor-block-exec", cluster)
+	if id, ok := auditor.lookupPolicyIdentity("varmor-cluster-varmor-block-exec"); !ok || id != cluster {
+		t.Fatalf("expected cluster identity %+v, got id=%+v ok=%v", cluster, id, ok)
+	}
+
+	// Delete removes only the targeted entry.
+	auditor.DeletePolicyIdentity("varmor-demo-nginx")
+	if _, ok := auditor.lookupPolicyIdentity("varmor-demo-nginx"); ok {
+		t.Fatalf("expected deleted profile to miss")
+	}
+	if _, ok := auditor.lookupPolicyIdentity("varmor-cluster-varmor-block-exec"); !ok {
+		t.Fatalf("expected unrelated entry to survive delete")
+	}
+}
+
+// TestPolicyIdentityConcurrentAccess exercises the RWMutex under -race by
+// running concurrent upserts, deletes and lookups against the cache.
+func TestPolicyIdentityConcurrentAccess(t *testing.T) {
+	auditor := newIdentityTestAuditor()
+
+	const workers = 16
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	wg.Add(workers * 3)
+
+	// Writers: upsert.
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				auditor.UpsertPolicyIdentity("varmor-demo-nginx",
+					PolicyIdentity{Kind: "VarmorPolicy", Name: "nginx", Namespace: "demo"})
+			}
+		}()
+	}
+
+	// Deleters.
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				auditor.DeletePolicyIdentity("varmor-demo-nginx")
+			}
+		}()
+	}
+
+	// Readers.
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_, _ = auditor.lookupPolicyIdentity("varmor-demo-nginx")
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/networkproxy/als/protocol.go
+++ b/pkg/networkproxy/als/protocol.go
@@ -1,0 +1,59 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package als holds the wire-level constants of the gRPC ALS (Access Log
+// Service) protocol shared between the NetworkProxy profile renderer (which
+// embeds them into the generated Envoy config) and the agent's auditor (which
+// parses them back out of incoming access-log entries). It is a dependency-free
+// leaf package so that pkg/auditor can consume the protocol contract without
+// importing any internal/ package.
+//
+// A change to any value here is a protocol break: the renderer and the auditor
+// must stay byte-compatible.
+package als
+
+const (
+	// DefaultALSClusterName is the CDS cluster name of the gRPC ALS endpoint.
+	// It is a fixed, shared convention so the renderer and the agent's
+	// auditor stay byte-compatible.
+	DefaultALSClusterName = "varmor_audit_als"
+
+	// LogNameClassDeny / LogNameClassAudit are the two log_name classes the
+	// renderer embeds (as "<class>:<profileName>") into each gRPC ALS
+	// access_log entry. The auditor parses the class to map an event to an
+	// action: deny -> DENIED, audit -> AUDIT. This is a shared convention
+	// between the renderer and the agent's auditor.
+	LogNameClassDeny  = "varmor_np_deny"
+	LogNameClassAudit = "varmor_np_audit"
+
+	// ALSFilterChainTagKey is the gRPC ALS custom_tag key whose literal value
+	// carries the originating Envoy filter chain name (e.g. "http_chain",
+	// "mitm_tls_dns_chain"). The renderer injects it as a literal custom_tag on
+	// each L7 access_log entry; the auditor reads it back from
+	// AccessLogCommon.custom_tags to attribute the event to its chain. The L4
+	// listener-level access_log is shared across the passthrough tls_chain and
+	// tcp_default_chain, so no chain tag is emitted there.
+	ALSFilterChainTagKey = "filter_chain"
+)
+
+// Filter chain names. These are the literal values used as the FilterChain.Name
+// throughout the translator; the auditor reports them back via the
+// ALSFilterChainTagKey custom_tag, so they are part of the shared protocol.
+const (
+	FilterChainNameHTTP       = "http_chain"
+	FilterChainNameMITMTLSDNS = "mitm_tls_dns_chain"
+	FilterChainNameMITMTLSIP  = "mitm_tls_ip_chain"
+	FilterChainNameTLS        = "tls_chain"
+	FilterChainNameTCPDefault = "tcp_default_chain"
+)

--- a/pkg/networkproxy/als/protocol_test.go
+++ b/pkg/networkproxy/als/protocol_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package als
+
+import "testing"
+
+// TestSharedConstants pins the wire-level constants that MUST stay
+// byte-compatible across the shared gRPC ALS protocol between the NetworkProxy
+// renderer and the agent's auditor. A change to any value here is a protocol
+// break and requires coordinated changes on both ends.
+func TestSharedConstants(t *testing.T) {
+	cases := map[string]string{
+		DefaultALSClusterName:     "varmor_audit_als",
+		LogNameClassDeny:          "varmor_np_deny",
+		LogNameClassAudit:         "varmor_np_audit",
+		ALSFilterChainTagKey:      "filter_chain",
+		FilterChainNameHTTP:       "http_chain",
+		FilterChainNameMITMTLSDNS: "mitm_tls_dns_chain",
+		FilterChainNameMITMTLSIP:  "mitm_tls_ip_chain",
+		FilterChainNameTLS:        "tls_chain",
+		FilterChainNameTCPDefault: "tcp_default_chain",
+	}
+	for got, want := range cases {
+		if got != want {
+			t.Errorf("shared constant = %q, want %q", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Enrich every violation event with the identity of the originating `VarmorPolicy` or `VarmorClusterPolicy`. The agent now registers the authoritative policy identity from the `ArmorProfile` owner reference, and all enforcers (AppArmor, BPF, Seccomp, NetworkProxy) include `policyKind`, `policyName`, and `policyNamespace` in the structured violations log.

## Motivation
The violations log previously exposed `profileName` but not the higher-level policy object that owns the profile. This made it hard for operators to correlate events back to the user-managed CRD (`VarmorPolicy` / `VarmorClusterPolicy`) in multi-tenant or multi-policy clusters. Adding policy identity closes this gap and aligns the audit output with the Kubernetes resource model.

## What Changed
1. **Shared ALS protocol constants**
   - Moved the 9 gRPC ALS wire-level constants (cluster name, log-name classes, filter-chain tags) from `internal/networkproxy/profile` to a new dependency-free leaf package `pkg/networkproxy/als`.
   - `pkg/auditor` now consumes these constants from `pkg/networkproxy/als` instead of `internal/networkproxy/profile`, eliminating the auditor's last dependency on an `internal/` package.
   - Added `protocol_test.go` to pin each constant's literal value and prevent accidental drift between the renderer and the auditor.

2. **Policy identity model** (`pkg/auditor/policy_identity.go`)
   - Added `PolicyIdentity{Kind, Name, Namespace}` type.
   - Added an in-memory cache (`PolicyIdentityCache`) with `Register` / `Lookup` APIs, keyed by profile name.
   - Cluster-scoped `VarmorClusterPolicy` identities leave `Namespace` empty; namespaced `VarmorPolicy` identities include the policy namespace.

3. **Agent registration** (`internal/agent/agent.go`)
   - On every `ArmorProfile` create/update, the agent derives the policy identity from the profile's controller `OwnerReference` (not from parsing the profile name, which is ambiguous).
   - The identity is registered in the auditor cache so all subsequent violations for that profile carry the correct policy metadata.

4. **Violation event enrichment** (`pkg/auditor/`)
   - AppArmor, BPF, Seccomp, and NetworkProxy collectors now call `recordViolation` / `recordNetworkProxyViolation` with the resolved `PolicyIdentity`, adding `policyKind`, `policyName`, and `policyNamespace` fields to the violations log.
   - NetworkProxy ALS records resolve the identity from the profile name embedded in the ALS `log_name`.

## Tests
- `pkg/networkproxy/als/protocol_test.go`: literal value guards for the shared ALS constants.
- `pkg/auditor/policy_identity_test.go`: cache register/lookup, cluster vs. namespaced identity handling.
- `pkg/auditor/als_test.go`: NetworkProxy events with resolved policy identity.
- `internal/agent/policy_identity_test.go`: `policyIdentityFromArmorProfile` correctness for `VarmorPolicy` and `VarmorClusterPolicy` owner references.
- Updated renderer/translator tests to reference the new `pkg/networkproxy/als` constants.

## Notes
- The policy identity cache is keyed by profile name and is intentionally small and in-memory; it is repopulated on every agent restart via the existing `ArmorProfile` watch.
- No CRD or API changes are introduced.
