### PR TITLE
fix(auditor): guard container caches with RWMutex to fix data race

### DIFF
--- a/internal/auditor/audit.go
+++ b/internal/auditor/audit.go
@@ -63,11 +63,11 @@ func (auditor *Auditor) processAuditEvent(event string) {
 		//   If so, we can't associate container information for violations.
 		var mntNsID uint32
 		var ok bool
-		if mntNsID, ok = auditor.mntNsIDCache[uint32(e.PID)]; !ok {
+		if mntNsID, ok = auditor.mntNsIDByPID(uint32(e.PID)); !ok {
 			mntNsID, _ = varmorutils.ReadMntNsID(uint32(e.PID))
 		}
 
-		info := auditor.containerCache[mntNsID]
+		info := auditor.containerByMntNsID(mntNsID)
 		auditor.log.V(2).Info("audit event",
 			"pod uid", info.PodUID,
 			"pod name", info.PodName,
@@ -159,11 +159,11 @@ func (auditor *Auditor) processAuditEvent(event string) {
 		//   If so, we can't associate container information for violations.
 		var mntNsID uint32
 		var ok bool
-		if mntNsID, ok = auditor.mntNsIDCache[uint32(e.PID)]; !ok {
+		if mntNsID, ok = auditor.mntNsIDByPID(uint32(e.PID)); !ok {
 			mntNsID, _ = varmorutils.ReadMntNsID(uint32(e.PID))
 		}
 
-		info := auditor.containerCache[mntNsID]
+		info := auditor.containerByMntNsID(mntNsID)
 		auditor.log.V(2).Info("audit event",
 			"pod uid", info.PodUID,
 			"pod name", info.PodName,

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -53,6 +53,12 @@ type Auditor struct {
 	TaskDeleteSyncCh       chan bool
 	mntNsIDCache           map[uint32]uint32                    // key: The init PID of contaienr, value: The mnt ns id
 	containerCache         map[uint32]varmortypes.ContainerInfo // key: The mnt ns id of container, value: The container information
+	// cacheMu guards mntNsIDCache and containerCache. They are written only
+	// by eventHandler on the containerd-event goroutine, but read from the
+	// audit-log tail goroutine (processAuditEvent) and the BPF ringbuf
+	// goroutine (readFromAuditEventRingBuf), so every access must hold this
+	// lock to avoid a data race.
+	cacheMu sync.RWMutex
 	// policyIdentityCache maps an ArmorProfile name to the authoritative
 	// identity of the VarmorPolicy/VarmorClusterPolicy that owns it. It is
 	// written by the agent from its ArmorProfile watch and read by every
@@ -166,16 +172,21 @@ func (auditor *Auditor) eventHandler(stopCh <-chan struct{}) {
 		select {
 		case info := <-auditor.TaskStartCh:
 			// Handle the creation event of target container
+			auditor.cacheMu.Lock()
 			auditor.mntNsIDCache[info.PID] = info.MntNsID
 			auditor.containerCache[info.MntNsID] = info
+			auditor.cacheMu.Unlock()
 		case info := <-auditor.TaskDeleteCh:
 			// Handle the deletion event of target container
+			auditor.cacheMu.Lock()
 			if mntNsID, ok := auditor.mntNsIDCache[info.PID]; ok {
 				delete(auditor.containerCache, mntNsID)
 				delete(auditor.mntNsIDCache, info.PID)
 			}
+			auditor.cacheMu.Unlock()
 		case <-auditor.TaskDeleteSyncCh:
 			// Handle those containers that exit while the monitor was offline
+			auditor.cacheMu.Lock()
 			for pid, mntNsID := range auditor.mntNsIDCache {
 				id, err := varmorutils.ReadMntNsID(pid)
 				if err != nil || mntNsID != id {
@@ -191,11 +202,33 @@ func (auditor *Auditor) eventHandler(stopCh <-chan struct{}) {
 					delete(auditor.mntNsIDCache, pid)
 				}
 			}
+			auditor.cacheMu.Unlock()
 		case <-stopCh:
 			logger.Info("stop handling the containerd events")
 			return
 		}
 	}
+}
+
+// containerByMntNsID returns the cached container information for the given
+// mnt namespace id. containerCache is written by eventHandler on the
+// containerd-event goroutine and read here from the audit-log tail and BPF
+// ringbuf goroutines, so access is guarded by cacheMu. A miss returns the
+// zero ContainerInfo (attribution is best-effort). Safe for concurrent use.
+func (auditor *Auditor) containerByMntNsID(mntNsID uint32) varmortypes.ContainerInfo {
+	auditor.cacheMu.RLock()
+	defer auditor.cacheMu.RUnlock()
+	return auditor.containerCache[mntNsID]
+}
+
+// mntNsIDByPID returns the cached mnt namespace id for the given container
+// init PID. The boolean reports whether an entry was found. Safe for
+// concurrent use.
+func (auditor *Auditor) mntNsIDByPID(pid uint32) (uint32, bool) {
+	auditor.cacheMu.RLock()
+	defer auditor.cacheMu.RUnlock()
+	id, ok := auditor.mntNsIDCache[pid]
+	return id, ok
 }
 
 // AddBehaviorEventNotifyChs add the audit event channel and bpf event channel for the subscriber

--- a/internal/auditor/bpf.go
+++ b/internal/auditor/bpf.go
@@ -162,6 +162,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			continue
 		}
 
+		// Snapshot the container information once under the cache lock. The
+		// containerd-event goroutine may mutate containerCache concurrently, so
+		// a single guarded read here both fixes the data race and keeps all
+		// fields of one event consistent.
+		info := auditor.containerByMntNsID(eventHeader.MntNs)
+
 		// Process the body of audit event
 		var e interface{}
 		switch eventHeader.Type {
@@ -180,12 +186,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			}
 
 			auditor.log.V(2).Info("audit event",
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
-				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
-				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
-				"image", auditor.containerCache[eventHeader.MntNs].Image,
+				"pod uid", info.PodUID,
+				"pod name", info.PodName,
+				"pod namespace", info.PodNamespace,
+				"container id", info.ContainerID,
+				"container name", info.ContainerName,
+				"image", info.Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"capability", e.(*BpfCapabilityEvent).Capability)
 
@@ -204,12 +210,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			}
 
 			auditor.log.V(2).Info("audit event",
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
-				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
-				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
-				"image", auditor.containerCache[eventHeader.MntNs].Image,
+				"pod uid", info.PodUID,
+				"pod name", info.PodName,
+				"pod namespace", info.PodNamespace,
+				"container id", info.ContainerID,
+				"container name", info.ContainerName,
+				"image", info.Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"path", e.(*BpfPathEvent).Path, "permissions", e.(*BpfPathEvent).Permissions)
 
@@ -228,12 +234,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			}
 
 			auditor.log.V(2).Info("audit event",
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
-				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
-				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
-				"image", auditor.containerCache[eventHeader.MntNs].Image,
+				"pod uid", info.PodUID,
+				"pod name", info.PodName,
+				"pod namespace", info.PodNamespace,
+				"container id", info.ContainerID,
+				"container name", info.ContainerName,
+				"image", info.Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"path", e.(*BpfPathEvent).Path, "permissions", e.(*BpfPathEvent).Permissions)
 
@@ -254,24 +260,24 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			switch event.Type {
 			case bpfenforcer.SocketType:
 				auditor.log.V(2).Info("audit event",
-					"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
-					"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
-					"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-					"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-					"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
-					"image", auditor.containerCache[eventHeader.MntNs].Image,
+					"pod uid", info.PodUID,
+					"pod name", info.PodName,
+					"pod namespace", info.PodNamespace,
+					"container id", info.ContainerID,
+					"container name", info.ContainerName,
+					"image", info.Image,
 					"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 					"domain", e.(*BpfNetworkEvent).Socket.Domain,
 					"type", e.(*BpfNetworkEvent).Socket.Type,
 					"protocol", e.(*BpfNetworkEvent).Socket.Protocol)
 			case bpfenforcer.ConnectType:
 				auditor.log.V(2).Info("audit event",
-					"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
-					"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
-					"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-					"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-					"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
-					"image", auditor.containerCache[eventHeader.MntNs].Image,
+					"pod uid", info.PodUID,
+					"pod name", info.PodName,
+					"pod namespace", info.PodNamespace,
+					"container id", info.ContainerID,
+					"container name", info.ContainerName,
+					"image", info.Image,
 					"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 					"dest ip", e.(*BpfNetworkEvent).Address.IP, "dest port", e.(*BpfNetworkEvent).Address.Port)
 			}
@@ -291,12 +297,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			}
 
 			auditor.log.V(2).Info("audit event",
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
-				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
-				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
-				"image", auditor.containerCache[eventHeader.MntNs].Image,
+				"pod uid", info.PodUID,
+				"pod name", info.PodName,
+				"pod namespace", info.PodNamespace,
+				"container id", info.ContainerID,
+				"container name", info.ContainerName,
+				"image", info.Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"permission", e.(*BpfPtraceEvent).Permission, "external", e.(*BpfPtraceEvent).External)
 
@@ -315,12 +321,12 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			}
 
 			auditor.log.V(2).Info("audit event",
-				"pod uid", auditor.containerCache[eventHeader.MntNs].PodUID,
-				"pod name", auditor.containerCache[eventHeader.MntNs].PodName,
-				"pod namespace", auditor.containerCache[eventHeader.MntNs].PodNamespace,
-				"container id", auditor.containerCache[eventHeader.MntNs].ContainerID,
-				"container name", auditor.containerCache[eventHeader.MntNs].ContainerName,
-				"image", auditor.containerCache[eventHeader.MntNs].Image,
+				"pod uid", info.PodUID,
+				"pod name", info.PodName,
+				"pod namespace", info.PodNamespace,
+				"container id", info.ContainerID,
+				"container name", info.ContainerName,
+				"image", info.Image,
 				"pid", eventHeader.Tgid, "ktime", eventHeader.Ktime, "mnt ns", eventHeader.MntNs,
 				"path", e.(*BpfMountEvent).Path,
 				"file system type", e.(*BpfMountEvent).Type,
@@ -333,19 +339,19 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			auditor.violationLogger.Warn().
 				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
-				Str("podUID", auditor.containerCache[eventHeader.MntNs].PodUID).
-				Str("podName", auditor.containerCache[eventHeader.MntNs].PodName).
-				Str("podNamespace", auditor.containerCache[eventHeader.MntNs].PodNamespace).
-				Str("containerID", auditor.containerCache[eventHeader.MntNs].ContainerID).
-				Str("containerName", auditor.containerCache[eventHeader.MntNs].ContainerName).
-				Str("image", auditor.containerCache[eventHeader.MntNs].Image).
+				Str("podUID", info.PodUID).
+				Str("podName", info.PodName).
+				Str("podNamespace", info.PodNamespace).
+				Str("containerID", info.ContainerID).
+				Str("containerName", info.ContainerName).
+				Str("image", info.Image).
 				Uint32("pid", eventHeader.Tgid).
 				Uint32("mntNsID", eventHeader.MntNs).
 				Uint64("eventTimestamp", eventHeader.Ktime/uint64(time.Second)+auditor.bootTimestamp).
 				Str("enforcer", "BPF").
 				Str("action", "DENIED").
-				Str("profileName", auditor.containerCache[eventHeader.MntNs].ProfileName).
-				Func(auditor.withPolicyIdentity(auditor.containerCache[eventHeader.MntNs].ProfileName)).
+				Str("profileName", info.ProfileName).
+				Func(auditor.withPolicyIdentity(info.ProfileName)).
 				Interface("event", e).Msg("violation event")
 
 		case bpfenforcer.AuditAction:
@@ -353,24 +359,24 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 			auditor.violationLogger.Warn().
 				Interface("metadata", auditor.auditEventMetadata).
 				Str("nodeName", auditor.nodeName).
-				Str("podUID", auditor.containerCache[eventHeader.MntNs].PodUID).
-				Str("podName", auditor.containerCache[eventHeader.MntNs].PodName).
-				Str("podNamespace", auditor.containerCache[eventHeader.MntNs].PodNamespace).
-				Str("containerID", auditor.containerCache[eventHeader.MntNs].ContainerID).
-				Str("containerName", auditor.containerCache[eventHeader.MntNs].ContainerName).
-				Str("image", auditor.containerCache[eventHeader.MntNs].Image).
+				Str("podUID", info.PodUID).
+				Str("podName", info.PodName).
+				Str("podNamespace", info.PodNamespace).
+				Str("containerID", info.ContainerID).
+				Str("containerName", info.ContainerName).
+				Str("image", info.Image).
 				Uint32("pid", eventHeader.Tgid).
 				Uint32("mntNsID", eventHeader.MntNs).
 				Uint64("eventTimestamp", eventHeader.Ktime/uint64(time.Second)+auditor.bootTimestamp).
 				Str("enforcer", "BPF").
 				Str("action", "AUDIT").
-				Str("profileName", auditor.containerCache[eventHeader.MntNs].ProfileName).
-				Func(auditor.withPolicyIdentity(auditor.containerCache[eventHeader.MntNs].ProfileName)).
+				Str("profileName", info.ProfileName).
+				Func(auditor.withPolicyIdentity(info.ProfileName)).
 				Interface("event", e).Msg("violation event")
 
 		case bpfenforcer.AllowedAction:
 			// Send behavior event to the corresponding subscriber
-			profileName := auditor.containerCache[eventHeader.MntNs].ProfileName
+			profileName := info.ProfileName
 			if ch, ok := auditor.bpfEventChs[profileName]; ok {
 				ch <- BpfEvent{
 					Header: BpfEventHeader{

--- a/test/e2e/manifests/networkproxy/vpol-mitm-audit.yaml
+++ b/test/e2e/manifests/networkproxy/vpol-mitm-audit.yaml
@@ -19,9 +19,9 @@ spec:
     networkProxyConfig:
       mitm:
         domains:
-          - httpbin.org
+          - postman-echo.com
         headerMutations:
-          - domain: httpbin.org
+          - domain: postman-echo.com
             headers:
               - name: X-Request-Source
                 value: varmor-audit

--- a/test/e2e/manifests/networkproxy/vpol-mitm-deny.yaml
+++ b/test/e2e/manifests/networkproxy/vpol-mitm-deny.yaml
@@ -20,9 +20,9 @@ spec:
     networkProxyConfig:
       mitm:
         domains:
-          - httpbin.org
+          - postman-echo.com
         headerMutations:
-          - domain: httpbin.org
+          - domain: postman-echo.com
             headers:
               - name: X-Request-Source
                 value: varmor-agent
@@ -35,14 +35,14 @@ spec:
               description: "explicit admin deny (takes precedence)"
               match:
                 hosts:
-                  - httpbin.org
+                  - postman-echo.com
                 paths:
                   - prefix: "/admin/"
                   - exact: "/secret"
             - qualifiers: ["allow", "audit"]
               match:
                 hosts:
-                  - httpbin.org
+                  - postman-echo.com
                 paths:
                   - exact: "/get"
                   - prefix: "/headers"

--- a/test/e2e/testcases/networkproxy-deny.sh
+++ b/test/e2e/testcases/networkproxy-deny.sh
@@ -35,7 +35,7 @@
 TEST_NAME="networkproxy-mitm-path-deny"
 
 # Test description
-TEST_DESCRIPTION="Testing NetworkProxy MITM L7 path deny (httpbin.org/admin -> 403)"
+TEST_DESCRIPTION="Testing NetworkProxy MITM L7 path deny (postman-echo.com/admin -> 403)"
 
 # Namespace
 NAMESPACE="demo"
@@ -59,13 +59,13 @@ POD_SELECTOR="app=e2e-networkproxy-mitm-deny"
 CONTAINER_NAME="c0"
 
 # Initial command - allowed path GET /get should succeed
-INITIAL_COMMAND="curl -sSL --fail -o /dev/null https://httpbin.org/get"
+INITIAL_COMMAND="curl -sSL --fail -o /dev/null https://postman-echo.com/get"
 
 # Initial command expected status code (0 means allowed)
 INITIAL_EXPECTED_STATUS=0
 
 # Verification command - denied path /admin/login -> 403 -> curl --fail exits 22
-VERIFY_COMMAND="curl -sSL --fail -o /dev/null https://httpbin.org/admin/login"
+VERIFY_COMMAND="curl -sSL --fail -o /dev/null https://postman-echo.com/admin/login"
 
 # Verification expected status code (22 = curl HTTP error, request was blocked)
 VERIFY_EXPECTED_STATUS=22

--- a/test/e2e/testcases/networkproxy.sh
+++ b/test/e2e/testcases/networkproxy.sh
@@ -20,7 +20,7 @@
 #   The Envoy sidecar performs a full MITM round-trip: it decrypts the TLS
 #   request with the injected vArmor CA, applies the headerMutation
 #   (X-Request-Source: varmor-audit), re-encrypts and forwards upstream.
-#   httpbin.org/headers echoes back whatever headers it received, so seeing
+#   postman-echo.com/headers echoes back whatever headers it received, so seeing
 #   "varmor-audit" in the response body proves decrypt + inject + forward all
 #   work. This is the MITM-specific capability that the deny test cannot cover.
 #
@@ -38,7 +38,7 @@
 TEST_NAME="networkproxy-mitm-header-inject"
 
 # Test description
-TEST_DESCRIPTION="Testing NetworkProxy MITM header mutation echoed by httpbin.org/headers"
+TEST_DESCRIPTION="Testing NetworkProxy MITM header mutation echoed by postman-echo.com/headers"
 
 # Namespace
 NAMESPACE="demo"
@@ -62,13 +62,13 @@ POD_SELECTOR="app=e2e-networkproxy-mitm-audit"
 CONTAINER_NAME="c0"
 
 # Initial command (warm-up; not asserted by the framework)
-INITIAL_COMMAND="curl -sSL -o /dev/null https://httpbin.org/headers"
+INITIAL_COMMAND="curl -sSL -o /dev/null https://postman-echo.com/headers"
 
 # Initial command expected status code
 INITIAL_EXPECTED_STATUS=0
 
-# Verification command - the injected header must be echoed back by httpbin
-VERIFY_COMMAND='curl -sSL https://httpbin.org/headers | grep -q "varmor-audit"'
+# Verification command - the injected header must be echoed back by postman-echo
+VERIFY_COMMAND='curl -sSL https://postman-echo.com/headers | grep -q "varmor-audit"'
 
 # Verification expected status code (0 means grep found the injected header)
 VERIFY_EXPECTED_STATUS=0


### PR DESCRIPTION
## Summary
Fix a pre-existing data race on `containerCache` and `mntNsIDCache` that is detected by `go test -race`. The maps are written only by `eventHandler` on the containerd-event goroutine, but read concurrently from the audit-log tail goroutine (`processAuditEvent`) and the BPF ringbuf goroutine (`readFromAuditEventRingBuf`).

## What Changed
- Added `cacheMu sync.RWMutex` to `Auditor` and guarded every access to `mntNsIDCache` and `containerCache`.
- **Writes**: `eventHandler` now locks the mutex around the three mutation sites:
  - `TaskStart` (insert)
  - `TaskDelete` (delete)
  - `TaskDeleteSync` (bulk reconcile-and-delete)
- **Reads**: introduced two `RLock`-guarded getters:
  - `containerByMntNsID(mntNsID uint32)`
  - `mntNsIDByPID(pid uint32) (uint32, bool)`
  The two `audit.go` read sites now route through these getters.
- **BPF consistency fix**: `bpf.go` now snapshots the container info once under the read lock immediately after parsing the event header and reuses that snapshot for all logged fields. This both removes the race and guarantees that every field of a single event is consistent (previously each field performed a separate unsynchronized map read, risking half-deleted state).

## Behavior
- No behavior change on the happy path.
- Lookups remain best-effort: a cache miss returns the zero `ContainerInfo`.
- The fix is purely about thread safety and event-field consistency.
