### PR TITLE
feat(policy-advisor): detect shell usage via script file extensions

### DIFF
--- a/tools/policy-advisor/built-in-rules.json
+++ b/tools/policy-advisor/built-in-rules.json
@@ -514,7 +514,8 @@
       "enforcers": ["seccomp"],
       "conflicts": {
         "features": ["load-bpf"],
-        "syscalls": ["bpf"]
+        "syscalls": ["bpf"],
+        "capabilities": ["bpf"]
       }
     },
     {
@@ -611,7 +612,7 @@
       "id": "disable-shell",
       "enforcers": ["apparmor", "bpf"],
       "conflicts": {
-        "executions": ["sh", "bash", "dash"]
+        "executions": ["sh", "bash", "dash", ".sh"]
       }
     },
     {

--- a/tools/policy-advisor/test_utils.py
+++ b/tools/policy-advisor/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from utils import files_conflict_with_rule
+from utils import files_conflict_with_rule, retrieve_executions_from_behavior_data
 
 class TestFunctions(unittest.TestCase):
   def test_files_conflict_with_rule(self):
@@ -449,6 +449,47 @@ class TestFunctions(unittest.TestCase):
       for index, testcase in enumerate(value["testcases"]):
         print("Run testcase %d" % index)
         self.assertEqual(files_conflict_with_rule(value["rules"], testcase["files"]), testcase["conflict"])
+
+  def test_retrieve_executions_from_behavior_data(self):
+    # Script files executed via binfmt_script are recorded by their script path
+    # (e.g. /var/lib/cilium/bpf/init.sh) without the sh/bash/dash interpreter
+    # binary. The extractor must additionally emit the extension token (.sh) so
+    # that rules like disable-shell can detect shell usage in such cases.
+    testcases = [
+      {
+        "behavior_data": {
+          "data": {
+            "dynamicResult": {
+              "appArmor": {
+                "executions": ["/var/lib/cilium/bpf/init.sh", "/usr/bin/curl"]
+              },
+              "bpf": {
+                "executions": ["/opt/entrypoint.py"]
+              }
+            }
+          }
+        },
+        "expected": ["init.sh", ".sh", "curl", "entrypoint.py", ".py"]
+      },
+      {
+        # No extension -> only the basename is emitted (no empty ext token).
+        "behavior_data": {
+          "data": {
+            "dynamicResult": {
+              "appArmor": {
+                "executions": ["/bin/bash", "/usr/local/bin/node"]
+              }
+            }
+          }
+        },
+        "expected": ["bash", "node"]
+      }
+    ]
+
+    print("------- retrieve_executions_from_behavior_data -------")
+    for index, testcase in enumerate(testcases):
+      print("Run testcase %d" % index)
+      self.assertEqual(retrieve_executions_from_behavior_data(testcase["behavior_data"]), testcase["expected"])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/policy-advisor/utils.py
+++ b/tools/policy-advisor/utils.py
@@ -42,9 +42,17 @@ def retrieve_syscalls_from_behavior_data(behavior_data):
 def retrieve_executions_from_behavior_data(behavior_data):
   executions = []
   for execution in behavior_data.get("data", {}).get("dynamicResult", {}).get("appArmor", {}).get("executions", []):
-    executions.append(os.path.basename(execution))
+    base = os.path.basename(execution)
+    executions.append(base)
+    ext = os.path.splitext(base)[1]
+    if ext:
+      executions.append(ext)
   for execution in behavior_data.get("data", {}).get("dynamicResult", {}).get("bpf", {}).get("executions", []):
-    executions.append(os.path.basename(execution))
+    base = os.path.basename(execution)
+    executions.append(base)
+    ext = os.path.splitext(base)[1]
+    if ext:
+      executions.append(ext)
   return executions
 
 

--- a/website/src/pages/policy-advisor.js
+++ b/website/src/pages/policy-advisor.js
@@ -38,12 +38,22 @@ const retrieveExecutionsFromModel = (model = {}) => {
   const executions = [];
   if (model.data && model.data.dynamicResult && model.data.dynamicResult.appArmor && model.data.dynamicResult.appArmor.executions) {
     for (const execution of model.data.dynamicResult.appArmor.executions) {
-      executions.push(execution.split('/').pop());
+      const base = execution.split('/').pop();
+      executions.push(base);
+      const dotIndex = base.lastIndexOf('.');
+      if (dotIndex > 0) {
+        executions.push(base.slice(dotIndex));
+      }
     }
   }
   if (model.data && model.data.dynamicResult && model.data.dynamicResult.bpf && model.data.dynamicResult.bpf.executions) {
     for (const execution of model.data.dynamicResult.bpf.executions) {
-      executions.push(execution.split('/').pop());
+      const base = execution.split('/').pop();
+      executions.push(base);
+      const dotIndex = base.lastIndexOf('.');
+      if (dotIndex > 0) {
+        executions.push(base.slice(dotIndex));
+      }
     }
   }
   return executions;

--- a/website/static/built-in-rules.json
+++ b/website/static/built-in-rules.json
@@ -514,7 +514,8 @@
       "enforcers": ["seccomp"],
       "conflicts": {
         "features": ["load-bpf"],
-        "syscalls": ["bpf"]
+        "syscalls": ["bpf"],
+        "capabilities": ["bpf"]
       }
     },
     {
@@ -611,7 +612,7 @@
       "id": "disable-shell",
       "enforcers": ["apparmor", "bpf"],
       "conflicts": {
-        "executions": ["sh", "bash", "dash"]
+        "executions": ["sh", "bash", "dash", ".sh"]
       }
     },
     {


### PR DESCRIPTION
## Summary
Improve the Policy Advisor's shell-usage detection so that scripts executed via `binfmt_script` (recorded only by their script path, without the `sh`/`bash`/`dash` interpreter binary) are still recognized as shell usage. This is done by also emitting the file-extension token (e.g. `.sh`) during execution extraction.

## What Changed
1. **Execution extraction**
   - `tools/policy-advisor/utils.py` (`retrieve_executions_from_behavior_data`): now emits both the basename and the file extension (when present) for each recorded execution path.
   - `website/src/pages/policy-advisor.js` (`retrieveExecutionsFromModel`): mirrored the same logic in the website version.

2. **Built-in rule conflicts**
   - Added `.sh` to the `disable-shell` rule's `executions` conflict list (`sh`, `bash`, `dash`, `.sh`).
   - Added `bpf` capability to the `disable-load-bpf` rule's conflicts (alongside the existing `load-bpf` feature and `bpf` syscall).
   - Updated both `tools/policy-advisor/built-in-rules.json` and `website/static/built-in-rules.json`.

3. **Tests**
   - Added `test_retrieve_executions_from_behavior_data` in `tools/policy-advisor/test_utils.py` covering:
     - Script paths that produce both basename and extension tokens.
     - Paths without extensions that produce only the basename.

## Example
A behavior record containing `/var/lib/cilium/bpf/init.sh` now yields `[..., "init.sh", ".sh", ...]`, allowing `disable-shell` to flag it even when no interpreter binary was recorded.

## Notes
- No CRD or API changes.
- The Python CLI tool and the website Policy Advisor page are kept in sync.
