### PR TITLE
refactor(policy): simplify NP-secret error flow and drop forward-compat ownerReference block

### DIFF
--- a/internal/policy/clusterpolicy_controller.go
+++ b/internal/policy/clusterpolicy_controller.go
@@ -235,9 +235,8 @@ func (c *ClusterPolicyController) handleAddVarmorClusterPolicy(vcp *varmor.Varmo
 					err.Error())
 				if err != nil {
 					logger.Error(err, "statuscommon.UpdateVarmorClusterPolicyStatus()")
-					return err
 				}
-				return nil
+				return err
 			}
 		}
 	}
@@ -250,9 +249,8 @@ func (c *ClusterPolicyController) handleAddVarmorClusterPolicy(vcp *varmor.Varmo
 			err.Error())
 		if err != nil {
 			logger.Error(err, "statuscommon.UpdateVarmorClusterPolicyStatus()")
-			return err
 		}
-		return nil
+		return err
 	}
 
 	if vcp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
@@ -341,9 +339,8 @@ func (c *ClusterPolicyController) handleUpdateVarmorClusterPolicy(newVcp *varmor
 					err.Error())
 				if err != nil {
 					logger.Error(err, "statuscommon.UpdateVarmorClusterPolicyStatus()")
-					return err
 				}
-				return nil
+				return err
 			}
 		}
 	}
@@ -368,9 +365,8 @@ func (c *ClusterPolicyController) handleUpdateVarmorClusterPolicy(newVcp *varmor
 			err.Error())
 		if err != nil {
 			logger.Error(err, "statuscommon.UpdateVarmorClusterPolicyStatus()")
-			return err
 		}
-		return nil
+		return err
 	}
 
 	newApSpec := oldAp.Spec.DeepCopy()
@@ -426,20 +422,6 @@ func (c *ClusterPolicyController) handleUpdateVarmorClusterPolicy(newVcp *varmor
 
 		logger.Info("3.2. update the ArmorProfile object")
 		oldAp.Spec = *newApSpec
-		forceSetOwnerReference(oldAp, newVcp, true)
-		_, err = c.varmorInterface.ArmorProfiles(varmorconfig.Namespace).Update(context.Background(), oldAp, metav1.UpdateOptions{})
-		if err != nil {
-			logger.Error(err, "ArmorProfile().Update()")
-			if varmorutils.IsRequestSizeError(err) {
-				return statuscommon.UpdateVarmorClusterPolicyStatus(
-					c.varmorInterface, newVcp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-					"Error",
-					"The profiles are too large to update the existing ArmorProfile object.")
-			}
-			return err
-		}
-	} else if len(oldAp.OwnerReferences) == 0 {
-		// Forward compatibility, add an ownerReference to the existing ArmorProfile object
 		forceSetOwnerReference(oldAp, newVcp, true)
 		_, err = c.varmorInterface.ArmorProfiles(varmorconfig.Namespace).Update(context.Background(), oldAp, metav1.UpdateOptions{})
 		if err != nil {

--- a/internal/policy/policy_controller.go
+++ b/internal/policy/policy_controller.go
@@ -233,9 +233,8 @@ func (c *PolicyController) handleAddVarmorPolicy(vp *varmor.VarmorPolicy, profil
 			err.Error())
 		if err != nil {
 			logger.Error(err, "statuscommon.UpdateVarmorPolicyStatus()")
-			return err
 		}
-		return nil
+		return err
 	}
 
 	ap, egressInfo, err := varmorprofile.NewArmorProfile(c.kubeClient, c.varmorInterface, vp, false, c.enableServiceEgressControl, c.enablePodEgressControl, logger)
@@ -246,9 +245,8 @@ func (c *PolicyController) handleAddVarmorPolicy(vp *varmor.VarmorPolicy, profil
 			err.Error())
 		if err != nil {
 			logger.Error(err, "statuscommon.UpdateVarmorPolicyStatus()")
-			return err
 		}
-		return nil
+		return err
 	}
 
 	if vp.Spec.Policy.Mode == varmor.BehaviorModelingMode {
@@ -334,9 +332,8 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 			err.Error())
 		if err != nil {
 			logger.Error(err, "statuscommon.UpdateVarmorPolicyStatus()")
-			return err
 		}
-		return nil
+		return err
 	}
 
 	// Third, create a new ArmorProfileSpec with the updated policy
@@ -359,9 +356,8 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 			err.Error())
 		if err != nil {
 			logger.Error(err, "statuscommon.UpdateVarmorPolicyStatus()")
-			return err
 		}
-		return nil
+		return err
 	}
 
 	newApSpec := oldAp.Spec.DeepCopy()
@@ -417,20 +413,6 @@ func (c *PolicyController) handleUpdateVarmorPolicy(newVp *varmor.VarmorPolicy, 
 
 		logger.Info("3.2. update the ArmorProfile object")
 		oldAp.Spec = *newApSpec
-		forceSetOwnerReference(oldAp, newVp, false)
-		_, err = c.varmorInterface.ArmorProfiles(oldAp.Namespace).Update(context.Background(), oldAp, metav1.UpdateOptions{})
-		if err != nil {
-			logger.Error(err, "ArmorProfile().Update()")
-			if varmorutils.IsRequestSizeError(err) {
-				return statuscommon.UpdateVarmorPolicyStatus(
-					c.varmorInterface, newVp, "", false, varmor.VarmorPolicyError, varmor.VarmorPolicyUpdated, apicorev1.ConditionFalse,
-					"Error",
-					"The profiles are too large to update the existing ArmorProfile object.")
-			}
-			return err
-		}
-	} else if len(oldAp.OwnerReferences) == 0 {
-		// Forward compatibility, add an ownerReference to the existing ArmorProfile object
 		forceSetOwnerReference(oldAp, newVp, false)
 		_, err = c.varmorInterface.ArmorProfiles(oldAp.Namespace).Update(context.Background(), oldAp, metav1.UpdateOptions{})
 		if err != nil {


### PR DESCRIPTION
## Summary
Clean up the policy controllers by collapsing redundant NetworkProxy-secret error handling and removing an obsolete forward-compatibility path for ArmorProfile owner references.

## What Changed
1. **Simplified NP-secret error flow**
   - In both `policy_controller.go` and `clusterpolicy_controller.go`, the error branches after `statuscommon.UpdateVarmor*PolicyStatus()` previously returned `err` if the status update failed, otherwise returned `nil`.
   - These two returns are now collapsed into a single `return err`, which is correct because the original error (from the NP-secret operation) is what should be propagated regardless of whether the status update succeeded.

2. **Removed forward-compatibility ownerReference block**
   - Deleted the `else if len(oldAp.OwnerReferences) == 0` branch in the update handlers of both controllers.
   - This branch was a migration path that added an `ownerReference` to existing ArmorProfile objects created before the controller started setting one. Backward compatibility for that transition is no longer required, so the dead code is removed.

## Files
- `internal/policy/policy_controller.go`
- `internal/policy/clusterpolicy_controller.go`

## Notes
- No behavioral change for newly created or normally updated policies.
- No CRD or API changes.
