### PR TITLE
fix(policycacher): handle nil NetworkProxyConfig transitions on update

### DIFF
--- a/internal/policycacher/policycacher.go
+++ b/internal/policycacher/policycacher.go
@@ -110,11 +110,22 @@ func (c *PolicyCacher) updateVarmorClusterPolicy(oldObj, newObj interface{}) {
 	}
 	c.ClusterPolicyEnforcer[key] = vcp.Spec.Policy.Enforcer
 	c.ClusterPolicyMode[key] = vcp.Spec.Policy.Mode
-	// Update only mutable proxy config fields (MITM, Resources).
-	// ProxyUID, ProxyPort, ProxyAdminPort are immutable after creation
-	// and must not be overwritten — they are baked into each Pod's
-	// iptables rules at init time.
-	updateProxyConfigMutableFields(c.ClusterPolicyProxyConfig[key], vcp.Spec.Policy.NetworkProxyConfig)
+	// Handle nil transitions explicitly, then update only mutable proxy
+	// config fields (MITM, Resources). ProxyUID, ProxyPort, ProxyAdminPort
+	// are immutable after creation and must not be overwritten — they are
+	// baked into each Pod's iptables rules at init time.
+	newProxyConfig := vcp.Spec.Policy.NetworkProxyConfig
+	cachedProxyConfig := c.ClusterPolicyProxyConfig[key]
+	switch {
+	case cachedProxyConfig == nil && newProxyConfig != nil:
+		// Proxy config was added during the update: cache a full copy.
+		c.ClusterPolicyProxyConfig[key] = newProxyConfig.DeepCopy()
+	case cachedProxyConfig != nil && newProxyConfig == nil:
+		// Proxy config was removed during the update: drop the cached entry.
+		c.ClusterPolicyProxyConfig[key] = nil
+	default:
+		updateProxyConfigMutableFields(cachedProxyConfig, newProxyConfig)
+	}
 }
 
 func (c *PolicyCacher) deleteVarmorClusterPolicy(obj interface{}) {
@@ -169,8 +180,21 @@ func (c *PolicyCacher) updateVarmorPolicy(oldObj, newObj interface{}) {
 	}
 	c.PolicyEnforcer[key] = vp.Spec.Policy.Enforcer
 	c.PolicyMode[key] = vp.Spec.Policy.Mode
-	// Update only mutable proxy config fields (MITM, Resources).
-	updateProxyConfigMutableFields(c.PolicyProxyConfig[key], vp.Spec.Policy.NetworkProxyConfig)
+	// Handle nil transitions explicitly, then update only mutable proxy
+	// config fields (MITM, Resources). ProxyUID, ProxyPort, ProxyAdminPort
+	// are immutable after creation and must not be overwritten.
+	newProxyConfig := vp.Spec.Policy.NetworkProxyConfig
+	cachedProxyConfig := c.PolicyProxyConfig[key]
+	switch {
+	case cachedProxyConfig == nil && newProxyConfig != nil:
+		// Proxy config was added during the update: cache a full copy.
+		c.PolicyProxyConfig[key] = newProxyConfig.DeepCopy()
+	case cachedProxyConfig != nil && newProxyConfig == nil:
+		// Proxy config was removed during the update: drop the cached entry.
+		c.PolicyProxyConfig[key] = nil
+	default:
+		updateProxyConfigMutableFields(cachedProxyConfig, newProxyConfig)
+	}
 }
 
 func (c *PolicyCacher) deleteVarmorPolicy(obj interface{}) {


### PR DESCRIPTION
## Summary
Fix a bug in `PolicyCacher` where adding or removing `NetworkProxyConfig` on an existing policy was not reflected in the cached config, causing the mutation webhook to inject stale or nil proxy settings.

## Root Cause
`updateVarmorPolicy` and `updateVarmorClusterPolicy` only called `updateProxyConfigMutableFields`, which short-circuits when the cached config is `nil`. As a result:
- When a policy created **without** a `NetworkProxyConfig` was later updated to add one (MITM / Resources), the new config was never cached, so the webhook injected a nil proxy config.
- When a policy created **with** a `NetworkProxyConfig` was later updated to remove it, the cached entry was left stale.

## Fix
Explicitly handle the three possible nil transitions before falling back to mutable-field updates:
| cached | new | action |
|--------|-----|--------|
| `nil` | non-`nil` | Cache a full deep copy of the new config. |
| non-`nil` | `nil` | Drop the cached entry. |
| non-`nil` | non-`nil` | Update only mutable fields (`MITM`, `Resources`), leaving immutable `ProxyUID` / `ProxyPort` / `ProxyAdminPort` untouched. |

## Files
- `internal/policycacher/policycacher.go`

## Notes
- The immutable fields (`ProxyUID`, `ProxyPort`, `ProxyAdminPort`) remain protected because they are baked into each Pod's iptables rules at init time and must not change after creation.
- No CRD or API changes.
