### PR TITLE
fix(auditor): guard subscriber channel maps with an RWMutex to fix data race

### DIFF
--- a/internal/auditor/audit.go
+++ b/internal/auditor/audit.go
@@ -118,7 +118,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Func(auditor.withPolicyIdentity(profileName)).
 				Interface("event", e).Msg("violation event")
 		case AllowedAction:
-			if ch, ok := auditor.auditEventChs[profileName]; ok {
+			if ch, ok := auditor.auditEventChByProfile(profileName); ok {
 				// Send behavior event to the corresponding subscriber
 				ch <- event
 			} else {
@@ -186,14 +186,17 @@ func (auditor *Auditor) processAuditEvent(event string) {
 			profileName = info.ProfileName
 		}
 
-		ch, ok := auditor.auditEventChs[profileName]
+		ch, ok := auditor.auditEventChByProfile(profileName)
 		if ok {
 			// Send the behavior event to the corresponding subscriber
 			ch <- event
 			return
 		}
 
-		if len(auditor.auditEventChs) == 0 {
+		// Snapshot the subscriber channels once under the lock so the
+		// broadcast below never touches the map concurrently with an update.
+		subscriberChs := auditor.snapshotAuditEventChs()
+		if len(subscriberChs) == 0 {
 			// Only record the event when there is no policy in the BehaviorModeling mode.
 			// This can reduce the noise in the violation log.
 			// The events of the policy in the DefenseInDepth or EnhanceProtect mode will
@@ -217,7 +220,7 @@ func (auditor *Auditor) processAuditEvent(event string) {
 				Interface("event", e).Msg("violation event")
 		} else {
 			// Send the behavior event to all subscribers
-			for _, ch := range auditor.auditEventChs {
+			for _, ch := range subscriberChs {
 				ch <- event
 			}
 		}

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -65,14 +65,21 @@ type Auditor struct {
 	// violation emission path, so it is guarded by policyIdentityMu.
 	policyIdentityCache map[string]PolicyIdentity // key: profile name
 	policyIdentityMu    sync.RWMutex
-	auditEventChs       map[string]chan<- string   // auditEventChs used for sending apparmor & seccomp behavior event to subscribers, key: profile name, value: audit event channel
-	bpfEventChs         map[string]chan<- BpfEvent // bpfEventChs used for sending bpf behavior event to subscribers, key: profile name, value: bpf event channel
-	auditLogPath        string
-	auditLogTail        *tail.Tail
-	savedRateLimit      uint64
-	auditRbMap          *ebpf.Map
-	auditEventMetadata  map[string]interface{} // auditEventMetadata used for storing additional information of the violation event
-	violationLogger     zerolog.Logger
+	// chsMu guards auditEventChs and bpfEventChs. They are mutated by
+	// BehaviorModeller.Run/stop on the modeller goroutine when subscribers
+	// are dynamically added/removed, but read from the audit-log tail
+	// goroutine (processAuditEvent) and the BPF ringbuf goroutine
+	// (readFromAuditEventRingBuf), so every access must hold this lock to
+	// avoid a concurrent map read/write fatal error.
+	chsMu              sync.RWMutex
+	auditEventChs      map[string]chan<- string   // auditEventChs used for sending apparmor & seccomp behavior event to subscribers, key: profile name, value: audit event channel
+	bpfEventChs        map[string]chan<- BpfEvent // bpfEventChs used for sending bpf behavior event to subscribers, key: profile name, value: bpf event channel
+	auditLogPath       string
+	auditLogTail       *tail.Tail
+	savedRateLimit     uint64
+	auditRbMap         *ebpf.Map
+	auditEventMetadata map[string]interface{} // auditEventMetadata used for storing additional information of the violation event
+	violationLogger    zerolog.Logger
 	// alsSocketPath is the host-side UDS path the NetworkProxy ALS gRPC
 	// server listens on. It is injected by the caller (the agent); an empty
 	// path disables the ALS collector.
@@ -231,17 +238,54 @@ func (auditor *Auditor) mntNsIDByPID(pid uint32) (uint32, bool) {
 	return id, ok
 }
 
+// auditEventChByProfile returns the audit-event channel registered for the
+// given profile and whether one exists. Guarded by chsMu so it is safe to
+// call from the audit-log tail and BPF ringbuf goroutines concurrently with
+// AddBehaviorEventNotifyChs/DeleteBehaviorEventNotifyCh. The channel is
+// returned by value so the caller can send on it after releasing the lock.
+func (auditor *Auditor) auditEventChByProfile(profileName string) (chan<- string, bool) {
+	auditor.chsMu.RLock()
+	defer auditor.chsMu.RUnlock()
+	ch, ok := auditor.auditEventChs[profileName]
+	return ch, ok
+}
+
+// bpfEventChByProfile returns the bpf-event channel registered for the given
+// profile and whether one exists. Guarded by chsMu. Safe for concurrent use.
+func (auditor *Auditor) bpfEventChByProfile(profileName string) (chan<- BpfEvent, bool) {
+	auditor.chsMu.RLock()
+	defer auditor.chsMu.RUnlock()
+	ch, ok := auditor.bpfEventChs[profileName]
+	return ch, ok
+}
+
+// snapshotAuditEventChs returns a snapshot of all registered audit-event
+// channels taken under chsMu. Callers broadcast to the returned slice after
+// releasing the lock so a blocking send never stalls subscriber updates.
+func (auditor *Auditor) snapshotAuditEventChs() []chan<- string {
+	auditor.chsMu.RLock()
+	defer auditor.chsMu.RUnlock()
+	chs := make([]chan<- string, 0, len(auditor.auditEventChs))
+	for _, ch := range auditor.auditEventChs {
+		chs = append(chs, ch)
+	}
+	return chs
+}
+
 // AddBehaviorEventNotifyChs add the audit event channel and bpf event channel for the subscriber
 // The subscriber parameter is the name of profile
 func (auditor *Auditor) AddBehaviorEventNotifyChs(subscriber string, auditEventCh *chan string, bpfEventCh *chan BpfEvent) {
+	auditor.chsMu.Lock()
 	if bpfEventCh != nil {
 		auditor.bpfEventChs[subscriber] = *bpfEventCh
 	}
 	if auditEventCh != nil {
 		auditor.auditEventChs[subscriber] = *auditEventCh
 	}
+	auditEventChCount := len(auditor.auditEventChs)
+	auditor.chsMu.Unlock()
 
-	if len(auditor.auditEventChs) == 1 {
+	if auditEventChCount == 1 {
 		err := auditor.setRateLimit()
 		if err != nil {
 			auditor.log.Error(err, "auditor.setRateLimit()")
@@ -252,10 +296,13 @@ func (auditor *Auditor) AddBehaviorEventNotifyChs(subscriber string, auditEventC
 // DeleteBehaviorEventNotifyCh delete the audit event channel and bpf event channel for the subscriber
 // The subscriber parameter is the name of profile
 func (auditor *Auditor) DeleteBehaviorEventNotifyCh(subscriber string) {
+	auditor.chsMu.Lock()
 	delete(auditor.bpfEventChs, subscriber)
 	delete(auditor.auditEventChs, subscriber)
+	auditEventChCount := len(auditor.auditEventChs)
+	auditor.chsMu.Unlock()
 
-	if len(auditor.auditEventChs) == 0 {
+	if auditEventChCount == 0 {
 		err := auditor.restoreRateLimit()
 		if err != nil {
 			auditor.log.Error(err, "auditor.restoreRateLimit()")

--- a/internal/auditor/bpf.go
+++ b/internal/auditor/bpf.go
@@ -377,7 +377,7 @@ func (auditor *Auditor) readFromAuditEventRingBuf() {
 		case bpfenforcer.AllowedAction:
 			// Send behavior event to the corresponding subscriber
 			profileName := info.ProfileName
-			if ch, ok := auditor.bpfEventChs[profileName]; ok {
+			if ch, ok := auditor.bpfEventChByProfile(profileName); ok {
 				ch <- BpfEvent{
 					Header: BpfEventHeader{
 						Action: bpfenforcer.EnforcementActionMap[eventHeader.Action],

--- a/internal/auditor/subscriber_race_test.go
+++ b/internal/auditor/subscriber_race_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Test_SubscriberChs_ConcurrentAccess exercises the subscriber channel maps
+// under concurrent mutation and reads. It mirrors the production goroutine
+// layout: BehaviorModeller.Run/stop add and remove subscribers while the
+// audit-log tail goroutine (processAuditEvent) and the BPF ringbuf goroutine
+// (readFromAuditEventRingBuf) look them up. Before chsMu guarded these maps,
+// this raced and could trip "fatal error: concurrent map read and map write".
+// Run with -race to detect a regression.
+func Test_SubscriberChs_ConcurrentAccess(t *testing.T) {
+	auditor := &Auditor{
+		auditEventChs: make(map[string]chan<- string),
+		bpfEventChs:   make(map[string]chan<- BpfEvent),
+		log:           log.Log.WithName("test"),
+	}
+
+	// Keep one permanent subscriber so len(auditEventChs) never hits the
+	// 1 / 0 boundary during the churn below, which would otherwise invoke
+	// setRateLimit/restoreRateLimit and touch the host sysctl. This test
+	// targets the map race only.
+	keepAudit := make(chan string, 1)
+	keepBpf := make(chan BpfEvent, 1)
+	kaCh := (chan<- string)(keepAudit)
+	kbCh := (chan<- BpfEvent)(keepBpf)
+	auditor.auditEventChs["keepalive"] = kaCh
+	auditor.bpfEventChs["keepalive"] = kbCh
+
+	const workers = 8
+	const iters = 2000
+	var wg sync.WaitGroup
+
+	// Writers: churn distinct subscribers so len stays >= 1 (keepalive).
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			ac := make(chan string, 1)
+			bc := make(chan BpfEvent, 1)
+			acPtr := ac
+			bcPtr := bc
+			name := fmt.Sprintf("subscriber-%d", id)
+			for i := 0; i < iters; i++ {
+				auditor.AddBehaviorEventNotifyChs(name, &acPtr, &bcPtr)
+				auditor.DeleteBehaviorEventNotifyCh(name)
+			}
+		}(w)
+	}
+
+	// Readers: hit every guarded read path.
+	for r := 0; r < workers; r++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			name := fmt.Sprintf("subscriber-%d", id)
+			for i := 0; i < iters; i++ {
+				_, _ = auditor.auditEventChByProfile(name)
+				_, _ = auditor.bpfEventChByProfile(name)
+				_ = auditor.snapshotAuditEventChs()
+			}
+		}(r)
+	}
+
+	wg.Wait()
+
+	// keepalive must survive the churn.
+	if _, ok := auditor.auditEventChByProfile("keepalive"); !ok {
+		t.Fatal("keepalive audit subscriber was unexpectedly removed")
+	}
+	if _, ok := auditor.bpfEventChByProfile("keepalive"); !ok {
+		t.Fatal("keepalive bpf subscriber was unexpectedly removed")
+	}
+}


### PR DESCRIPTION
## Summary
Fix a data race on `auditEventChs` and `bpfEventChs` that could cause a runtime "concurrent map read and map write" fatal error. The maps are mutated by `BehaviorModeller.Run`/`stop` when subscribers are dynamically added/removed, but read from the audit-log tail goroutine and the BPF ringbuf goroutine. The earlier `cacheMu` fix only covered `mntNsIDCache`/`containerCache`, leaving these subscriber maps unprotected.

## What Changed
- Added `chsMu sync.RWMutex` to guard both `auditEventChs` and `bpfEventChs`.
- **Writes**: `AddBehaviorEventNotifyChs` and `DeleteBehaviorEventNotifyCh` now take the write lock around map mutations, read `len()` under the same lock, and then perform `setRateLimit`/`restoreRateLimit` sysctl I/O outside the lock.
- **Reads**: introduced `RLock`-guarded helpers:
  - `auditEventChByProfile(profileName string) (chan<- string, bool)`
  - `bpfEventChByProfile(profileName string) (chan<- BpfEvent, bool)`
  - `snapshotAuditEventChs() []chan<- string`
  Each returns channels by value so callers send after releasing the lock, preventing a slow subscriber from stalling subscriber updates.
- **Seccomp broadcast path**: snapshots the audit-event channels once under the lock and ranges over the snapshot instead of the live map.

## Tests
- Added `internal/auditor/subscriber_race_test.go` with `Test_SubscriberChs_ConcurrentAccess`, which reproduces the production goroutine layout (concurrent add/delete vs. lookups/broadcast) and passes under `-race`.

## Files
- `internal/auditor/auditor.go`
- `internal/auditor/audit.go`
- `internal/auditor/bpf.go`
- `internal/auditor/subscriber_race_test.go`

## Notes
- No behavior change on the happy path.
- No CRD or API changes.
