### PR TITLE
fix(networkproxy): reject invalid NetworkProxyEgress.defaultAction values to prevent silent policy mode flip

### DIFF
--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -17,6 +17,7 @@ package policy
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
 	varmorconfig "github.com/bytedance/vArmor/internal/config"
@@ -444,6 +445,19 @@ func validateProxyResources(override *varmor.ProxyResourceOverride) (bool, strin
 func ValidateNetworkProxyEgress(egress *varmor.NetworkProxyEgress) (bool, string) {
 	if egress == nil {
 		return true, ""
+	}
+
+	// Validate defaultAction. Only "deny" and "allow" are legal. The downstream
+	// classifier treats any value other than "deny" as allow-default, so an
+	// unvalidated typo (e.g. "denny") would silently turn a deny-default
+	// (whitelist) policy into an allow-default (blacklist) one. Reject anything
+	// outside the legal set here. The comparison is case-insensitive to match
+	// the classifier's strings.EqualFold semantics.
+	if !strings.EqualFold(egress.DefaultAction, "deny") &&
+		!strings.EqualFold(egress.DefaultAction, "allow") {
+		return false, fmt.Sprintf(
+			"egress.defaultAction: %q is invalid, must be \"deny\" or \"allow\"",
+			egress.DefaultAction)
 	}
 
 	// Validate HTTP rules

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1008,6 +1008,7 @@ func TestValidateNetworkProxyEgress_Nil(t *testing.T) {
 
 func TestValidateNetworkProxyEgress_ValidInput(t *testing.T) {
 	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "deny",
 		HTTPRules: []varmor.NetworkProxyHTTPRule{
 			{
 				Match: varmor.HTTPMatch{
@@ -1033,6 +1034,7 @@ func TestValidateNetworkProxyEgress_ValidInput(t *testing.T) {
 
 func TestValidateNetworkProxyEgress_UnsafeHost(t *testing.T) {
 	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "deny",
 		HTTPRules: []varmor.NetworkProxyHTTPRule{
 			{
 				Match: varmor.HTTPMatch{
@@ -1048,6 +1050,7 @@ func TestValidateNetworkProxyEgress_UnsafeHost(t *testing.T) {
 
 func TestValidateNetworkProxyEgress_UnsafePath(t *testing.T) {
 	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "deny",
 		HTTPRules: []varmor.NetworkProxyHTTPRule{
 			{
 				Match: varmor.HTTPMatch{
@@ -1065,6 +1068,7 @@ func TestValidateNetworkProxyEgress_UnsafePath(t *testing.T) {
 
 func TestValidateNetworkProxyEgress_UnsafeMethod(t *testing.T) {
 	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "deny",
 		HTTPRules: []varmor.NetworkProxyHTTPRule{
 			{
 				Match: varmor.HTTPMatch{
@@ -1080,6 +1084,7 @@ func TestValidateNetworkProxyEgress_UnsafeMethod(t *testing.T) {
 
 func TestValidateNetworkProxyEgress_UnsafeIP(t *testing.T) {
 	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "deny",
 		Rules: []varmor.NetworkProxyEgressRule{
 			{
 				IP: "10.0.0.1\"\ninjection: true",
@@ -1093,6 +1098,7 @@ func TestValidateNetworkProxyEgress_UnsafeIP(t *testing.T) {
 
 func TestValidateNetworkProxyEgress_UnsafeCIDR(t *testing.T) {
 	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "deny",
 		Rules: []varmor.NetworkProxyEgressRule{
 			{
 				CIDR: "10.0.0.0/8\"\ninjection",
@@ -1106,6 +1112,7 @@ func TestValidateNetworkProxyEgress_UnsafeCIDR(t *testing.T) {
 
 func TestValidateNetworkProxyEgress_UnsafeNEL(t *testing.T) {
 	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "deny",
 		HTTPRules: []varmor.NetworkProxyHTTPRule{
 			{
 				Match: varmor.HTTPMatch{
@@ -1121,6 +1128,7 @@ func TestValidateNetworkProxyEgress_UnsafeNEL(t *testing.T) {
 
 func TestValidateNetworkProxyEgress_UnsafeLS(t *testing.T) {
 	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "deny",
 		HTTPRules: []varmor.NetworkProxyHTTPRule{
 			{
 				Match: varmor.HTTPMatch{
@@ -1136,6 +1144,7 @@ func TestValidateNetworkProxyEgress_UnsafeLS(t *testing.T) {
 
 func TestValidateNetworkProxyEgress_UnsafePathPrefix(t *testing.T) {
 	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "deny",
 		HTTPRules: []varmor.NetworkProxyHTTPRule{
 			{
 				Match: varmor.HTTPMatch{
@@ -1149,4 +1158,38 @@ func TestValidateNetworkProxyEgress_UnsafePathPrefix(t *testing.T) {
 	valid, msg := ValidateNetworkProxyEgress(egress)
 	assert.False(t, valid)
 	assert.Contains(t, msg, "unsafe characters")
+}
+
+func TestValidateNetworkProxyEgress_DefaultActionAllow(t *testing.T) {
+	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "allow",
+	}
+	valid, msg := ValidateNetworkProxyEgress(egress)
+	assert.True(t, valid, "defaultAction \"allow\" should pass: %s", msg)
+}
+
+func TestValidateNetworkProxyEgress_DefaultActionCaseInsensitive(t *testing.T) {
+	for _, action := range []string{"Deny", "DENY", "Allow", "ALLOW"} {
+		egress := &varmor.NetworkProxyEgress{DefaultAction: action}
+		valid, msg := ValidateNetworkProxyEgress(egress)
+		assert.True(t, valid, "defaultAction %q should pass: %s", action, msg)
+	}
+}
+
+func TestValidateNetworkProxyEgress_DefaultActionTypo(t *testing.T) {
+	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "denny",
+	}
+	valid, msg := ValidateNetworkProxyEgress(egress)
+	assert.False(t, valid, "typo defaultAction should be rejected")
+	assert.Contains(t, msg, "defaultAction")
+}
+
+func TestValidateNetworkProxyEgress_DefaultActionEmpty(t *testing.T) {
+	egress := &varmor.NetworkProxyEgress{
+		DefaultAction: "",
+	}
+	valid, msg := ValidateNetworkProxyEgress(egress)
+	assert.False(t, valid, "empty defaultAction should be rejected")
+	assert.Contains(t, msg, "defaultAction")
 }


### PR DESCRIPTION
## Summary

Validate `NetworkProxyEgress.defaultAction` against the legal value set `{deny, allow}` so that typos or an empty value cannot silently flip a deny-default (whitelist) egress policy into an allow-default (blacklist) one.

## Root Cause

`defaultAction` was accepted as an arbitrary string. Downstream logic (`classifyEgress`) treats any value other than `"deny"` as allow-default using `strings.EqualFold`, which means a typo like `"denny"` or an omitted value would change the enforcement semantics without any error. For whitelist-style NetworkProxy policies this is a security-relevant misconfiguration.

## What Changed

- Added explicit validation in `ValidateNetworkProxyEgress()` that rejects any `defaultAction` outside `{deny, allow}`.
- The check is case-insensitive to match the classifier semantics.
- The empty string is also rejected, forcing users to make an explicit choice.

## Tests

- Added `DefaultAction="deny"` to all existing valid NetworkProxy egress test cases so they continue to pass.
- Added new unit tests covering:
  - `allow` is accepted
  - case-insensitive `Deny`, `DENY`, `Allow`, `ALLOW` are accepted
  - typo `"denny"` is rejected
  - empty string is rejected

## Files Changed

- `internal/policy/validate.go` — added `defaultAction` validation
- `internal/policy/validate_test.go` — updated existing tests and added new test cases
