### PR TITLE
fix(mitm): reject mismatched CA cert/key pairs in ParseCA

### DIFF
--- a/internal/networkproxy/mitm/ca.go
+++ b/internal/networkproxy/mitm/ca.go
@@ -162,6 +162,24 @@ func ParseCA(certPEM, keyPEM []byte) (*CACertificate, error) {
 		return nil, fmt.Errorf("failed to parse CA private key: %w", err)
 	}
 
+	// Ensure the parsed certificate and private key are an actual key pair.
+	// x509.ParseCertificate / ParseECPrivateKey each succeed independently, so
+	// a Secret whose mitm-ca.crt and mitm-ca.key were crossed with a different
+	// CA would still parse cleanly here. Without this check such a mismatch is
+	// only detected later, when x509.CreateCertificate is called during leaf
+	// signing and fails with "provided PrivateKey doesn't match parent's
+	// PublicKey"; because the reuse path in buildOrReuseMITMMaterial does not
+	// fall back to generating a fresh CA once ParseCA succeeds, the policy
+	// would be stuck failing every reconcile instead of self-healing. Reject
+	// the mismatch here so the caller treats it as "no reusable CA".
+	certPub, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("CA certificate public key is not an ECDSA key")
+	}
+	if !certPub.Equal(key.Public()) {
+		return nil, fmt.Errorf("CA certificate public key does not match the provided private key")
+	}
+
 	return &CACertificate{
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,

--- a/internal/networkproxy/mitm/ca_test.go
+++ b/internal/networkproxy/mitm/ca_test.go
@@ -200,6 +200,26 @@ func TestParseCA_NonCACertificate(t *testing.T) {
 	}
 }
 
+func TestParseCA_MismatchedKeyPair(t *testing.T) {
+	// Two independent CAs: certPEM from the first, keyPEM from the second.
+	// Each PEM parses fine on its own, but they are not a key pair, so ParseCA
+	// must reject them instead of returning a CA that fails only later during
+	// leaf signing.
+	ca1, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA() 1 failed: %v", err)
+	}
+	ca2, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA() 2 failed: %v", err)
+	}
+
+	_, err = ParseCA(ca1.CertPEM, ca2.KeyPEM)
+	if err == nil {
+		t.Fatal("ParseCA() should fail when the certificate and private key are not a pair")
+	}
+}
+
 func TestPEMFormat(t *testing.T) {
 	ca, err := GenerateCA()
 	if err != nil {


### PR DESCRIPTION
## Summary

Add a key-pair consistency check to `ParseCA()` so that a crossed or mismatched `mitm-ca.crt`/`mitm-ca.key` Secret is rejected immediately instead of causing every subsequent reconcile to fail during leaf signing.

## Problem

`ParseCA()` previously parsed the certificate and EC private key independently and only verified `cert.IsCA`. Because `x509.ParseCertificate` and `x509.ParseECPrivateKey` each succeed on their own, a Secret whose cert and key came from two different CAs would still parse successfully. The mismatch was only detected later when `x509.CreateCertificate` was called during leaf signing with the error:

```
provided PrivateKey doesn't match parent's PublicKey
```

Worse, `buildOrReuseMITMMaterial()` does not fall back to generating a fresh CA once `ParseCA()` succeeds, so the policy would be stuck failing every reconcile rather than self-healing by regenerating the CA.

## What Changed

- After parsing the cert and key, `ParseCA()` now verifies that `cert.PublicKey` and `key.Public()` are the same ECDSA public key using `ecdsa.PublicKey.Equal()`.
- If the public keys do not match, `ParseCA()` returns an error so the caller treats it as "no reusable CA" and regenerates a fresh one.
- Added a guard for non-ECDSA public keys in the CA certificate.

## Tests

- Added `TestParseCA_MismatchedKeyPair`: generates two independent CAs and confirms that mixing the cert from one with the key from the other fails in `ParseCA()` rather than succeeding silently.

## Files Changed

- `internal/networkproxy/mitm/ca.go` — added cert/key public-key equality check
- `internal/networkproxy/mitm/ca_test.go` — added `TestParseCA_MismatchedKeyPair`
