### PR TITLE
fix(networkproxy): snapshot cluster-policy maps in ProxyConfigPropagator to fix data race

### DIFF
--- a/internal/policy/proxy_config_propagator.go
+++ b/internal/policy/proxy_config_propagator.go
@@ -86,13 +86,22 @@ func (p *ProxyConfigPropagator) addNamespace(obj interface{}) {
 	logger := p.log
 	ns := obj.(*v1.Namespace).Name
 
-	for key, enforcers := range p.policyCacher.ClusterPolicyEnforcer {
+	// Snapshot the cluster-policy enforcer/mode maps under the cacher's read
+	// lock instead of ranging over the shared maps directly. The maps are
+	// written concurrently by the PolicyCacher informer handlers, so iterating
+	// them here without synchronization races those writers and can trigger a
+	// "concurrent map iteration and map write" fatal error. Snapshotting also
+	// keeps the blocking apiserver I/O below out of the cacher's critical
+	// section.
+	enforcerByKey, modeByKey := p.policyCacher.SnapshotClusterPolicyEnforcers()
+
+	for key, enforcers := range enforcerByKey {
 		e := varmortypes.GetEnforcerType(enforcers)
 		if (e & varmortypes.NetworkProxy) == 0 {
 			continue
 		}
 
-		if p.policyCacher.ClusterPolicyMode[key] == varmor.BehaviorModelingMode {
+		if modeByKey[key] == varmor.BehaviorModelingMode {
 			continue
 		}
 

--- a/internal/policycacher/policycacher.go
+++ b/internal/policycacher/policycacher.go
@@ -241,6 +241,27 @@ func (c *PolicyCacher) GetClusterPolicyEntry(key string) (string, varmor.VarmorP
 	return c.ClusterPolicyEnforcer[key], c.ClusterPolicyMode[key], c.ClusterPolicyProxyConfig[key]
 }
 
+// SnapshotClusterPolicyEnforcers returns copies of the cluster-scoped enforcer
+// and mode maps taken under the read lock. Callers can iterate the returned
+// maps without holding the lock, which avoids racing the informer handlers that
+// mutate ClusterPolicyEnforcer / ClusterPolicyMode (add/update/delete). This is
+// preferred over exposing the maps directly: the propagator's per-entry work
+// performs blocking apiserver I/O, which must not run while the cacher lock is
+// held. It is safe to call from multiple goroutines.
+func (c *PolicyCacher) SnapshotClusterPolicyEnforcers() (map[string]string, map[string]varmor.VarmorPolicyMode) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	enforcers := make(map[string]string, len(c.ClusterPolicyEnforcer))
+	for k, v := range c.ClusterPolicyEnforcer {
+		enforcers[k] = v
+	}
+	modes := make(map[string]varmor.VarmorPolicyMode, len(c.ClusterPolicyMode))
+	for k, v := range c.ClusterPolicyMode {
+		modes[k] = v
+	}
+	return enforcers, modes
+}
+
 // GetPolicyEntry returns the cached enforcer, mode, and proxy config for a namespace-scoped policy key.
 // It is safe to call from multiple goroutines.
 func (c *PolicyCacher) GetPolicyEntry(key string) (string, varmor.VarmorPolicyMode, *varmor.NetworkProxyConfig) {

--- a/internal/policycacher/snapshot_race_test.go
+++ b/internal/policycacher/snapshot_race_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policycacher
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
+)
+
+// Test_SnapshotClusterPolicyEnforcers_ConcurrentAccess reproduces the data
+// race between the ProxyConfigPropagator (which reads the cluster-policy
+// enforcer/mode maps on Namespace add events) and the PolicyCacher informer
+// handlers (which mutate those maps on ClusterPolicy add/update/delete events).
+//
+// Before the fix the propagator ranged over ClusterPolicyEnforcer directly
+// without holding the cacher lock, which under `go test -race` reports a data
+// race and can trigger a "concurrent map iteration and map write" fatal error.
+// SnapshotClusterPolicyEnforcers takes the read lock and returns copies, so a
+// reader can iterate safely while writers mutate the maps concurrently.
+func Test_SnapshotClusterPolicyEnforcers_ConcurrentAccess(t *testing.T) {
+	c := &PolicyCacher{
+		ClusterPolicyEnforcer: make(map[string]string),
+		ClusterPolicyMode:     make(map[string]varmor.VarmorPolicyMode),
+	}
+
+	const (
+		writers = 8
+		readers = 8
+		iters   = 2000
+	)
+
+	var wg sync.WaitGroup
+
+	// Writers mirror the cacher's informer handlers: mutate the maps under the
+	// write lock.
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				key := fmt.Sprintf("ns-%d/policy-%d", w, i%16)
+				c.mutex.Lock()
+				c.ClusterPolicyEnforcer[key] = "NetworkProxy"
+				c.ClusterPolicyMode[key] = varmor.BehaviorModelingMode
+				c.mutex.Unlock()
+
+				c.mutex.Lock()
+				delete(c.ClusterPolicyEnforcer, key)
+				delete(c.ClusterPolicyMode, key)
+				c.mutex.Unlock()
+			}
+		}(w)
+	}
+
+	// Readers mirror the propagator: snapshot then iterate outside the lock.
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				enforcerByKey, modeByKey := c.SnapshotClusterPolicyEnforcers()
+				for key := range enforcerByKey {
+					_ = enforcerByKey[key]
+					_ = modeByKey[key]
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Fix a data race in `ProxyConfigPropagator.addNamespace()` that occurred when iterating `PolicyCacher` cluster-scoped maps while the cacher's informer handlers mutated them concurrently.

## Problem

`ProxyConfigPropagator.addNamespace()` ranged over `PolicyCacher.ClusterPolicyEnforcer` and indexed `PolicyCacher.ClusterPolicyMode` without holding the cacher lock. Those maps are written concurrently by the cacher's informer handlers (`addVarmorClusterPolicy`, `update`, `delete`) under `mutex.Lock()`.

Because the propagator runs on a separate Namespace informer, a Namespace event concurrent with a ClusterPolicy event produced a concurrent read/write on the same Go map. The race detector flags this, and in production it can trigger a "concurrent map iteration and map write" fatal error that crashes the manager. This path is only active when the NetworkProxy enforcer is enabled.

## What Changed

- Added `PolicyCacher.SnapshotClusterPolicyEnforcers()`, which returns copies of the cluster-scoped enforcer and mode maps taken under the cacher's read lock.
- Updated `ProxyConfigPropagator.addNamespace()` to iterate the snapshot instead of the shared maps.
- Snapshotting keeps the blocking apiserver I/O in the propagator loop outside the cacher's critical section, avoiding lock contention while still eliminating the race.

## Tests

- Added `Test_SnapshotClusterPolicyEnforcers_ConcurrentAccess` in `internal/policycacher/snapshot_race_test.go`, which reproduces the concurrent reader/writer pattern and passes under `go test -race`.

## Files Changed

- `internal/policycacher/policycacher.go` — added `SnapshotClusterPolicyEnforcers()`
- `internal/policy/proxy_config_propagator.go` — use the snapshot in `addNamespace()`
- `internal/policycacher/snapshot_race_test.go` — added concurrent race test

## Notes

This race only exists when the NetworkProxy enforcer is enabled, because `ProxyConfigPropagator` is the component that propagates NetworkProxy configuration to Namespace-scoped resources.
