### PR TITLE
fix(auditor): serialize printk_ratelimit save/restore across subscriber 0↔1 boundary

### DIFF
--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -71,12 +71,19 @@ type Auditor struct {
 	// goroutine (processAuditEvent) and the BPF ringbuf goroutine
 	// (readFromAuditEventRingBuf), so every access must hold this lock to
 	// avoid a concurrent map read/write fatal error.
-	chsMu              sync.RWMutex
-	auditEventChs      map[string]chan<- string   // auditEventChs used for sending apparmor & seccomp behavior event to subscribers, key: profile name, value: audit event channel
-	bpfEventChs        map[string]chan<- BpfEvent // bpfEventChs used for sending bpf behavior event to subscribers, key: profile name, value: bpf event channel
-	auditLogPath       string
-	auditLogTail       *tail.Tail
-	savedRateLimit     uint64
+	chsMu          sync.RWMutex
+	auditEventChs  map[string]chan<- string   // auditEventChs used for sending apparmor & seccomp behavior event to subscribers, key: profile name, value: audit event channel
+	bpfEventChs    map[string]chan<- BpfEvent // bpfEventChs used for sending bpf behavior event to subscribers, key: profile name, value: bpf event channel
+	auditLogPath   string
+	auditLogTail   *tail.Tail
+	savedRateLimit uint64
+	// rateLimitMu serializes the 0<->1 subscriber-count boundary decision
+	// together with the setRateLimit/restoreRateLimit sysctl read-modify-write,
+	// so the count transition and the save/restore of savedRateLimit are
+	// atomic. It is deliberately separate from chsMu: the audit-log tail and
+	// BPF ringbuf reader goroutines only take chsMu, so they are never blocked
+	// by the slow sysctl I/O performed while holding rateLimitMu.
+	rateLimitMu        sync.Mutex
 	auditRbMap         *ebpf.Map
 	auditEventMetadata map[string]interface{} // auditEventMetadata used for storing additional information of the violation event
 	violationLogger    zerolog.Logger
@@ -275,6 +282,13 @@ func (auditor *Auditor) snapshotAuditEventChs() []chan<- string {
 // AddBehaviorEventNotifyChs add the audit event channel and bpf event channel for the subscriber
 // The subscriber parameter is the name of profile
 func (auditor *Auditor) AddBehaviorEventNotifyChs(subscriber string, auditEventCh *chan string, bpfEventCh *chan BpfEvent) {
+	// Hold rateLimitMu across the whole registration so no concurrent
+	// Add/Delete can change the subscriber count between the boundary check
+	// below and the setRateLimit call, which would otherwise corrupt
+	// savedRateLimit.
+	auditor.rateLimitMu.Lock()
+	defer auditor.rateLimitMu.Unlock()
+
 	auditor.chsMu.Lock()
 	if bpfEventCh != nil {
 		auditor.bpfEventChs[subscriber] = *bpfEventCh
@@ -296,6 +310,12 @@ func (auditor *Auditor) AddBehaviorEventNotifyChs(subscriber string, auditEventC
 // DeleteBehaviorEventNotifyCh delete the audit event channel and bpf event channel for the subscriber
 // The subscriber parameter is the name of profile
 func (auditor *Auditor) DeleteBehaviorEventNotifyCh(subscriber string) {
+	// Hold rateLimitMu across the whole deregistration so the count==0
+	// boundary check and restoreRateLimit form an atomic critical section
+	// with respect to concurrent Add/Delete calls.
+	auditor.rateLimitMu.Lock()
+	defer auditor.rateLimitMu.Unlock()
+
 	auditor.chsMu.Lock()
 	delete(auditor.bpfEventChs, subscriber)
 	delete(auditor.auditEventChs, subscriber)

--- a/internal/auditor/ratelimit_race_test.go
+++ b/internal/auditor/ratelimit_race_test.go
@@ -1,0 +1,122 @@
+// Copyright 2024 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Test_RateLimit_ConcurrentBoundary exercises the subscriber-count 0<->1
+// boundary that drives setRateLimit/restoreRateLimit. Multiple subscribers are
+// concurrently added and removed so the count repeatedly crosses 0<->1, which
+// is exactly where savedRateLimit is saved and restored.
+//
+// Before the rateLimitMu fix, the count check and the sysctl read-modify-write
+// were decoupled across the chsMu release, so a concurrent Add could observe an
+// already-zeroed sysctl value and overwrite savedRateLimit with 0. After that,
+// restoreRateLimit (guarded by savedRateLimit != 0) would silently skip and the
+// host printk_ratelimit would be left permanently at 0.
+//
+// This test fakes the sysctl layer with an in-memory value seeded to a non-zero
+// original. It asserts two invariants that only hold when the boundary decision
+// and the save/restore are atomic:
+//  1. savedRateLimit is never corrupted to 0 while a save is in effect.
+//  2. After all churn drains to zero subscribers, the fake sysctl value is
+//     restored to the original non-zero value.
+//
+// Run with -race to also catch any unsynchronized access to savedRateLimit.
+func Test_RateLimit_ConcurrentBoundary(t *testing.T) {
+	const originalRateLimit uint64 = 5
+
+	// fakeSysctl is an in-memory stand-in for /proc/sys/kernel/printk_ratelimit.
+	var sysctlMu sync.Mutex
+	fakeSysctl := originalRateLimit
+
+	origRead := sysctlRead
+	origWrite := sysctlWrite
+	defer func() {
+		sysctlRead = origRead
+		sysctlWrite = origWrite
+	}()
+
+	sysctlRead = func(path string) (string, error) {
+		sysctlMu.Lock()
+		defer sysctlMu.Unlock()
+		return fmt.Sprintf("%d", fakeSysctl), nil
+	}
+	sysctlWrite = func(path string, value uint64) error {
+		sysctlMu.Lock()
+		defer sysctlMu.Unlock()
+		fakeSysctl = value
+		return nil
+	}
+
+	auditor := &Auditor{
+		auditEventChs: make(map[string]chan<- string),
+		bpfEventChs:   make(map[string]chan<- BpfEvent),
+		log:           log.Log.WithName("test"),
+	}
+
+	var corrupted int32
+
+	const workers = 8
+	const iters = 3000
+	var wg sync.WaitGroup
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			ac := make(chan string, 1)
+			bc := make(chan BpfEvent, 1)
+			acPtr := ac
+			bcPtr := bc
+			name := fmt.Sprintf("subscriber-%d", id)
+			for i := 0; i < iters; i++ {
+				auditor.AddBehaviorEventNotifyChs(name, &acPtr, &bcPtr)
+				// This worker's own subscriber keeps the count >= 1 until its
+				// Delete below, so savedRateLimit must still remember the
+				// original non-zero value. Read it under rateLimitMu to stay
+				// race-free with concurrent set/restore.
+				auditor.rateLimitMu.Lock()
+				saved := auditor.savedRateLimit
+				auditor.rateLimitMu.Unlock()
+				if saved == 0 {
+					atomic.StoreInt32(&corrupted, 1)
+				}
+				auditor.DeleteBehaviorEventNotifyCh(name)
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	if atomic.LoadInt32(&corrupted) != 0 {
+		t.Fatal("savedRateLimit was corrupted to 0 while a subscriber was active; the boundary decision and sysctl save/restore are not atomic")
+	}
+
+	// All subscribers gone: the host sysctl must be restored to the original.
+	sysctlMu.Lock()
+	final := fakeSysctl
+	sysctlMu.Unlock()
+	if final != originalRateLimit {
+		t.Fatalf("printk_ratelimit not restored: got %d, want %d", final, originalRateLimit)
+	}
+}

--- a/internal/auditor/utils.go
+++ b/internal/auditor/utils.go
@@ -54,7 +54,7 @@ func readBootTime() (uint64, error) {
 	return 0, fmt.Errorf("btime not found")
 }
 
-func sysctlRead(path string) (string, error) {
+var sysctlRead = func(path string) (string, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
@@ -62,7 +62,7 @@ func sysctlRead(path string) (string, error) {
 	return strings.Trim(string(content), "\n"), nil
 }
 
-func sysctlWrite(path string, value uint64) error {
+var sysctlWrite = func(path string, value uint64) error {
 	file, err := os.OpenFile(path, os.O_WRONLY, 0)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Fix a race condition in `Auditor` that could corrupt `savedRateLimit` and permanently leave the host `printk_ratelimit` at `0` when behavior-event subscribers are added and removed concurrently.

## Problem

`AddBehaviorEventNotifyChs()` and `DeleteBehaviorEventNotifyCh()` previously read the subscriber count while holding `chsMu`, but called `setRateLimit()` / `restoreRateLimit()` after releasing the lock. Because `setRateLimit()` unconditionally overwrites `savedRateLimit` with the current sysctl value, a concurrent `Add` that observed an already-zeroed value could corrupt `savedRateLimit` to `0`.

Once `savedRateLimit == 0`, subsequent `restoreRateLimit()` calls would silently skip (it only restores when `savedRateLimit != 0`), leaving the host's `printk_ratelimit` permanently disabled.

## What Changed

- Added a dedicated `rateLimitMu sync.Mutex` to the `Auditor` struct.
- `AddBehaviorEventNotifyChs()` and `DeleteBehaviorEventNotifyCh()` now hold `rateLimitMu` for their entire operation, making the 0↔1 subscriber-count boundary decision and the sysctl read-modify-write one atomic critical section.
- `rateLimitMu` is deliberately separate from `chsMu`: the audit-log tail and BPF ringbuf reader goroutines continue to take only `chsMu`, so they are never blocked by the slow sysctl I/O performed under `rateLimitMu`.
- Made `sysctlRead` / `sysctlWrite` mockable (changed from plain functions to `var ... = func(...)`) so the race test can substitute in-memory implementations.

## Tests

- Added `Test_RateLimit_ConcurrentBoundary` in `internal/auditor/ratelimit_race_test.go`.
- The test churns the 0↔1 subscriber boundary concurrently and asserts:
  - `savedRateLimit` is never corrupted to `0` while a save is in effect.
  - After all subscribers are removed, the fake sysctl value is restored to the original non-zero value.
- Passes under `go test -race`.

## Files Changed

- `internal/auditor/auditor.go` — added `rateLimitMu` and wrapped Add/Delete paths
- `internal/auditor/utils.go` — made `sysctlRead` / `sysctlWrite` mockable
- `internal/auditor/ratelimit_race_test.go` — added concurrent boundary race test
