### PR TITLE
fix(crd): use int64 format for BPF mount flags to avoid int32 overflow

### DIFF
--- a/apis/varmor/v1beta1/armorprofile_types.go
+++ b/apis/varmor/v1beta1/armorprofile_types.go
@@ -77,7 +77,9 @@ type PtraceContent struct {
 
 type MountContent struct {
 	Mode              uint32      `json:"mode,omitempty"`
+	// +kubebuilder:validation:Format=int64
 	MountFlags        uint32      `json:"mountFlags"`
+	// +kubebuilder:validation:Format=int64
 	ReverseMountflags uint32      `json:"reverseMountflags"`
 	Pattern           PathPattern `json:"pattern"`
 	Fstype            string      `json:"fstype"`

--- a/config/crds/crd.varmor.org_armorprofilemodels.yaml
+++ b/config/crds/crd.varmor.org_armorprofilemodels.yaml
@@ -304,7 +304,7 @@ spec:
                               format: int32
                               type: integer
                             mountFlags:
-                              format: int32
+                              format: int64
                               type: integer
                             pattern:
                               properties:
@@ -319,7 +319,7 @@ spec:
                               - flags
                               type: object
                             reverseMountflags:
-                              format: int32
+                              format: int64
                               type: integer
                           required:
                           - fstype

--- a/config/crds/crd.varmor.org_armorprofiles.yaml
+++ b/config/crds/crd.varmor.org_armorprofiles.yaml
@@ -124,7 +124,7 @@ spec:
                               format: int32
                               type: integer
                             mountFlags:
-                              format: int32
+                              format: int64
                               type: integer
                             pattern:
                               properties:
@@ -139,7 +139,7 @@ spec:
                               - flags
                               type: object
                             reverseMountflags:
-                              format: int32
+                              format: int64
                               type: integer
                           required:
                           - fstype

--- a/manifests/varmor/templates/crds/crd.varmor.org_armorprofilemodels.yaml
+++ b/manifests/varmor/templates/crds/crd.varmor.org_armorprofilemodels.yaml
@@ -304,7 +304,7 @@ spec:
                               format: int32
                               type: integer
                             mountFlags:
-                              format: int32
+                              format: int64
                               type: integer
                             pattern:
                               properties:
@@ -319,7 +319,7 @@ spec:
                               - flags
                               type: object
                             reverseMountflags:
-                              format: int32
+                              format: int64
                               type: integer
                           required:
                           - fstype

--- a/manifests/varmor/templates/crds/crd.varmor.org_armorprofiles.yaml
+++ b/manifests/varmor/templates/crds/crd.varmor.org_armorprofiles.yaml
@@ -124,7 +124,7 @@ spec:
                               format: int32
                               type: integer
                             mountFlags:
-                              format: int32
+                              format: int64
                               type: integer
                             pattern:
                               properties:
@@ -139,7 +139,7 @@ spec:
                               - flags
                               type: object
                             reverseMountflags:
-                              format: int32
+                              format: int64
                               type: integer
                           required:
                           - fstype


### PR DESCRIPTION
## Summary

Change the OpenAPI format of `MountContent.mountFlags` and `MountContent.reverseMountflags` from `int32` to `int64` so that the full `uint32` bitmask range (including `0xFFFFFFFF`) can be persisted in `ArmorProfile` and `ArmorProfileModel` objects.

## Problem

`MountFlags` and `ReverseMountflags` are `uint32` bitmasks. Several built-in hardening rules (e.g. `disallow-mount-*`, `disallow-mount-disk-device`) and raw mount rules using `"all"` / `"*"` set these fields to `0xFFFFFFFF` (`4294967295`).

By default, `controller-gen` maps Go `uint32` to OpenAPI `format: int32`, whose maximum value is `2147483647`. `0xFFFFFFFF` therefore overflows the declared schema. Older API servers (e.g. v1.30) did not strictly enforce the `int32` range and accepted the value silently, but stricter API servers (e.g. v1.36) reject the object with:

```
Checked value must be of type integer with format int32 in spec.profile.bpf.mounts[0].mountFlags
```

## What Changed

- Added `+kubebuilder:validation:Format=int64` markers to `MountContent.MountFlags` and `MountContent.ReverseMountflags` in `apis/varmor/v1beta1/armorprofile_types.go`.
- Regenerated the CRD manifests so the schema now declares `format: int64` for both fields in:
  - `config/crds/crd.varmor.org_armorprofilemodels.yaml`
  - `config/crds/crd.varmor.org_armorprofiles.yaml`
  - `manifests/varmor/templates/crds/crd.varmor.org_armorprofilemodels.yaml`
  - `manifests/varmor/templates/crds/crd.varmor.org_armorprofiles.yaml`

The Go field type remains `uint32`, so the BPF map layout, enforcer assignments, and data-plane behavior are unchanged.

## Compatibility

This is a schema widening (`int32` → `int64`), which is backward compatible for upgrades. Existing values that fit in `int32` continue to validate, and values up to `0xFFFFFFFF` now validate as well.

## Files Changed

- `apis/varmor/v1beta1/armorprofile_types.go` — added kubebuilder format markers
- `config/crds/crd.varmor.org_armorprofilemodels.yaml` — regenerated schema
- `config/crds/crd.varmor.org_armorprofiles.yaml` — regenerated schema
- `manifests/varmor/templates/crds/crd.varmor.org_armorprofilemodels.yaml` — regenerated schema
- `manifests/varmor/templates/crds/crd.varmor.org_armorprofiles.yaml` — regenerated schema
