### PR TITLE
fix(behavior): parse AppArmor mount events in BehaviorModeling mode

### DIFF
--- a/apis/varmor/v1beta1/armorprofilemodel_types.go
+++ b/apis/varmor/v1beta1/armorprofilemodel_types.go
@@ -67,6 +67,7 @@ type AppArmor struct {
 	Network      *Network `json:"networks,omitempty"`
 	Ptraces      []Ptrace `json:"ptraces,omitempty"`
 	Signals      []Signal `json:"signals,omitempty"`
+	Mounts       []Mount  `json:"mounts,omitempty"`
 	Unhandled    []string `json:"unhandled,omitempty"`
 }
 

--- a/internal/behavior/preprocessor/apparmor.go
+++ b/internal/behavior/preprocessor/apparmor.go
@@ -66,6 +66,9 @@ type AaLogRecord struct {
 	Path          string
 	Interface     string
 	Member        string
+	FsType        string
+	Flags         string
+	SrcName       string
 }
 
 const (
@@ -434,8 +437,47 @@ func (p *DataPreprocessor) parseAppArmorEventForTree(event *AaLogRecord) error {
 		return nil
 	}
 
+	// Mount
+	if event.Operation == "mount" || event.Operation == "umount" {
+		if event.Name == "" && event.FsType == "" {
+			return nil
+		}
+
+		// Parse mount flags from the Flags field
+		var flags []string
+		if event.Flags != "" {
+			for _, flag := range strings.Split(event.Flags, ",") {
+				flag = strings.TrimSpace(flag)
+				if flag != "" && !varmorutils.InStringArray(flag, flags) {
+					flags = append(flags, flag)
+				}
+			}
+		}
+
+		// Check if we already have this mount entry
+		for i, mount := range p.behaviorData.DynamicResult.AppArmor.Mounts {
+			if mount.Path == event.Name && mount.Type == event.FsType {
+				// Merge flags
+				for _, flag := range flags {
+					if !varmorutils.InStringArray(flag, mount.Flags) {
+						p.behaviorData.DynamicResult.AppArmor.Mounts[i].Flags = append(p.behaviorData.DynamicResult.AppArmor.Mounts[i].Flags, flag)
+					}
+				}
+				return nil
+			}
+		}
+
+		// Add new mount entry
+		p.behaviorData.DynamicResult.AppArmor.Mounts = append(p.behaviorData.DynamicResult.AppArmor.Mounts, varmor.Mount{
+			Path:  event.Name,
+			Type:  event.FsType,
+			Flags: flags,
+		})
+		return nil
+	}
+
 	// Ignore change_hat, change_profile, and allow all signal, dbus...
-	unhandled := fmt.Sprintf("Resource - %v, ActiveHat - %v, AaMode - %v, Time - %v, Operation - %v, Profile - %v, Name - %v, Name2 - %v, Attr - %v, Parent - %v, Pid - %v, Task - %v, Info - %v, ErrorCode - %v, DeniedMask - %v, RequestedMask - %v, MagicToken - %v, Family - %v, Protocol - %v, SockType - %v, Fsuid - %v, Ouid - %v, Signal - %v, Peer - %v, PeerProfile - %v, Bus - %v, Path - %v, Interface - %v, Member - %v",
+	unhandled := fmt.Sprintf("Resource - %v, ActiveHat - %v, AaMode - %v, Time - %v, Operation - %v, Profile - %v, Name - %v, Name2 - %v, Attr - %v, Parent - %v, Pid - %v, Task - %v, Info - %v, ErrorCode - %v, DeniedMask - %v, RequestedMask - %v, MagicToken - %v, Family - %v, Protocol - %v, SockType - %v, Fsuid - %v, Ouid - %v, Signal - %v, Peer - %v, PeerProfile - %v, Bus - %v, Path - %v, Interface - %v, Member - %v, FsType - %v, Flags - %v, SrcName - %v",
 		event.Resource, event.ActiveHat, event.AaMode,
 		event.Time, event.Operation, event.Profile,
 		event.Name, event.Name2, event.Attr,
@@ -445,7 +487,8 @@ func (p *DataPreprocessor) parseAppArmorEventForTree(event *AaLogRecord) error {
 		event.Protocol, event.SockType, event.Fsuid,
 		event.Ouid, event.Signal, event.Peer,
 		event.PeerProfile, event.Bus, event.Path,
-		event.Interface, event.Member)
+		event.Interface, event.Member, event.FsType,
+		event.Flags, event.SrcName)
 	if !varmorutils.InStringArray(unhandled, p.behaviorData.DynamicResult.AppArmor.Unhandled) {
 		p.behaviorData.DynamicResult.AppArmor.Unhandled = append(p.behaviorData.DynamicResult.AppArmor.Unhandled, unhandled)
 	}
@@ -513,6 +556,10 @@ func parseAppArmorEvent(line string) (*AaLogRecord, error) {
 		r.Path = C.GoString(record.dbus_path)
 		r.Interface = C.GoString(record.dbus_interface)
 		r.Member = C.GoString(record.dbus_member)
+	} else if r.Operation == "mount" || r.Operation == "umount" {
+		r.FsType = C.GoString(record.fs_type)
+		r.Flags = C.GoString(record.flags)
+		r.SrcName = C.GoString(record.src_name)
 	}
 
 	if r.Time == 0 {

--- a/internal/profile/apparmor/builder.go
+++ b/internal/profile/apparmor/builder.go
@@ -166,12 +166,46 @@ func buildSignalRules(appArmor *varmor.AppArmor, profileName string, debug bool)
 	return ruleSet
 }
 
+func buildMountRules(appArmor *varmor.AppArmor) string {
+	ruleSet := "\n  # ---- MOUNT ----\n"
+
+	if len(appArmor.Mounts) == 0 {
+		// Default: allow umount if no mount behavior data
+		ruleSet += "  umount,\n"
+		return ruleSet
+	}
+
+	rules := make([]string, 0, len(appArmor.Mounts))
+	for _, mount := range appArmor.Mounts {
+		var rule string
+		if mount.Type != "" && len(mount.Flags) > 0 {
+			rule = fmt.Sprintf("  mount fstype=%s options=(%s) -> %s,\n",
+				mount.Type, strings.Join(mount.Flags, ","), mount.Path)
+		} else if mount.Type != "" {
+			rule = fmt.Sprintf("  mount fstype=%s -> %s,\n", mount.Type, mount.Path)
+		} else if len(mount.Flags) > 0 {
+			rule = fmt.Sprintf("  mount options=(%s) -> %s,\n",
+				strings.Join(mount.Flags, ","), mount.Path)
+		} else {
+			rule = fmt.Sprintf("  mount -> %s,\n", mount.Path)
+		}
+		rules = append(rules, rule)
+	}
+
+	// Always allow umount
+	rules = append(rules, "  umount,\n")
+
+	sort.Strings(rules)
+	ruleSet += strings.Join(rules, "")
+
+	return ruleSet
+}
+
 func buildDefaultAllowRules() string {
 	// From docker-default profile
 	//   https://github.com/moby/moby/blob/master/profiles/apparmor/template.go
 	//   https://github.com/containerd/containerd/blob/main/contrib/apparmor/template.go
 	ruleSet := "\n  # ---- ADDITIONAL ----\n"
-	ruleSet += "  umount,\n"
 	return ruleSet
 }
 
@@ -187,6 +221,7 @@ func GenerateProfileWithBehaviorModel(appArmor *varmor.AppArmor, debug bool) (st
 		ruleSet += buildNetworkRules(appArmor, debug)
 		ruleSet += buildPtraceRules(appArmor, profileName, debug)
 		ruleSet += buildSignalRules(appArmor, profileName, debug)
+		ruleSet += buildMountRules(appArmor)
 		ruleSet += buildDefaultAllowRules()
 
 		profile := fmt.Sprintf(defenseInDepthTemplate, profileName, ruleSet)


### PR DESCRIPTION
## Motivation

Fixes #307

BehaviorModeling mode currently does not parse AppArmor mount events, which means mount operations are not captured in the behavior model and cannot be used to generate accurate AppArmor profiles.

## Changes

- **Add Mounts field to AppArmor struct** (pis/varmor/v1beta1/armorprofilemodel_types.go)
  - Stores mount event data (path, filesystem type, mount flags)
  
- **Extend AaLogRecord structure** (internal/behavior/preprocessor/apparmor.go)
  - Add FsType, Flags, SrcName fields for mount event parsing
  - Extract mount-related fields from C record structure in parseAppArmorEvent
  - Implement mount/umount event parsing in parseAppArmorEventForTree
  - Update unhandled event logging to include mount fields

- **Generate mount rules from behavior data** (internal/profile/apparmor/builder.go)
  - Add buildMountRules function to generate AppArmor mount rules
  - Integrate mount rules into GenerateProfileWithBehaviorModel
  - Generate precise mount rules with fstype and options constraints

## Testing

**Local environment limitations**: Unable to run full integration tests locally due to:
- Requires Linux environment with AppArmor support
- Requires libapparmor development libraries
- Requires CGO compilation

**Relies on CI/CD automated testing** for:
- Unit test execution
- Integration test validation
- AppArmor profile generation verification

The implementation follows existing patterns in the codebase (similar to signal/ptrace event handling) and maintains backward compatibility.

## Checklist

- [x] Code follows the project's coding standards
- [x] Changes are minimal and focused on the specific issue
- [x] Implementation follows existing event handling patterns
- [x] Commit messages follow conventional format
- [ ] Tests will be validated by CI/CD (local environment constraints)

/cc @Danny-Wei