### PR TITLE
feat(networkproxy): add global default sidecar resources via varmor-config

### DIFF
--- a/internal/config/dynamic.go
+++ b/internal/config/dynamic.go
@@ -15,11 +15,13 @@
 package config
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/go-logr/logr"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformer "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -52,6 +54,48 @@ type DynamicConfig struct {
 	// to pick the NetworkProxy ALS audit volume topology (hostPath for runc vs.
 	// no hostPath for micro-VM); it does not affect any runtime behaviour.
 	MicroVMDetection MicroVMDetection `yaml:"microVMDetection"`
+
+	// NetworkProxy carries cluster-level defaults for the NetworkProxy enforcer,
+	// currently the global proxy-sidecar resource defaults. It is the middle
+	// layer of the sidecar resource merge chain (see ResolveProxyResources):
+	// per-policy override > this global config > built-in defaults.
+	NetworkProxy NetworkProxyDynamicConfig `yaml:"networkProxy"`
+}
+
+// NetworkProxyDynamicConfig holds cluster-level, hot-reloadable settings for
+// the NetworkProxy enforcer.
+type NetworkProxyDynamicConfig struct {
+	// DefaultResources are the cluster-wide default resource requirements for
+	// the proxy sidecar container. An administrator can tune sidecar resources
+	// once here instead of per policy. It is split into two independent tiers
+	// (nonMitm / mitm), mirroring the built-in defaults, because MITM sidecars
+	// run heavier (double TLS handshakes) than non-MITM ones.
+	DefaultResources ProxyDefaultResources `yaml:"defaultResources"`
+}
+
+// ProxyDefaultResources carries the global sidecar resource defaults as two
+// independent tiers, mirroring the built-in defaults: NonMITM applies to
+// sidecars without MITM, MITM applies to sidecars with MITM enabled. The tiers
+// are NOT inherited from one another — a MITM sidecar reads ONLY the mitm tier
+// and a non-MITM sidecar reads ONLY the nonMitm tier.
+//
+// Values are kept as strings (Kubernetes quantity syntax, e.g. "200m",
+// "256Mi") so the embedded YAML stays human-authorable; they are parsed into
+// corev1 quantities on read, and invalid values are ignored (and warned about
+// at load time) rather than rejecting the whole config.
+type ProxyDefaultResources struct {
+	// NonMITM is the tier applied to sidecars without MITM enabled.
+	NonMITM ProxyResourceTier `yaml:"nonMitm"`
+
+	// MITM is the tier applied to sidecars with MITM enabled.
+	MITM ProxyResourceTier `yaml:"mitm"`
+}
+
+// ProxyResourceTier is one resource tier (requests + limits) expressed as
+// quantity strings keyed by resource name (cpu, memory).
+type ProxyResourceTier struct {
+	Requests map[string]string `yaml:"requests"`
+	Limits   map[string]string `yaml:"limits"`
 }
 
 // MicroVMDetection is a set of signals; a Pod matching ANY of them is treated
@@ -154,7 +198,94 @@ func parseDynamicConfig(raw string, log logr.Logger) DynamicConfig {
 		log.Error(err, "failed to parse dynamic config, falling back to built-in defaults")
 		return defaultDynamicConfig()
 	}
+	warnInvalidProxyResourceValues(cfg.NetworkProxy.DefaultResources, log)
 	return cfg
+}
+
+// knownProxyResourceNames is the set of resource names the proxy sidecar
+// understands. Any other key (e.g. "cpuu") is almost certainly a typo: it would
+// otherwise be attached to the sidecar as a bogus resource while the intended
+// cpu/memory silently kept the built-in default. Such keys are dropped on read
+// (see parseResourceList) and warned about at load time.
+var knownProxyResourceNames = map[corev1.ResourceName]struct{}{
+	corev1.ResourceCPU:    {},
+	corev1.ResourceMemory: {},
+}
+
+// validateProxyResourceEntry validates one (name, value) entry from the global
+// proxy-resource config. It returns the parsed quantity when the entry is
+// usable, or a non-nil error explaining why it must be ignored:
+//   - an unknown resource name (typo; only cpu and memory are supported),
+//   - an unparseable Kubernetes quantity,
+//   - a non-positive quantity (zero or negative; ParseQuantity accepts "0" and
+//     "-5m", but neither is a meaningful sidecar request/limit).
+//
+// Both the load-time warner and the read-time parser call this, so the "what is
+// a valid entry" rule lives in exactly one place and the log warnings always
+// match what actually gets dropped.
+func validateProxyResourceEntry(name, value string) (resource.Quantity, error) {
+	if _, ok := knownProxyResourceNames[corev1.ResourceName(name)]; !ok {
+		return resource.Quantity{}, fmt.Errorf("unknown resource name %q (only cpu and memory are supported)", name)
+	}
+	q, err := resource.ParseQuantity(value)
+	if err != nil {
+		return resource.Quantity{}, err
+	}
+	if q.Sign() <= 0 {
+		return resource.Quantity{}, fmt.Errorf("quantity must be greater than zero, got %q", value)
+	}
+	return q, nil
+}
+
+// warnInvalidProxyResourceValues surfaces, at load time, every global
+// proxy-resource entry that will be ignored on read, plus any tier whose limit
+// is below its request. Nothing here rejects the config: invalid entries
+// degrade to the built-in default for that field (see parseResourceList) and a
+// limit-below-request only fails later at the kube-apiserver, so warning is the
+// only feedback channel for an otherwise silent, cluster-wide misconfiguration.
+func warnInvalidProxyResourceValues(dr ProxyDefaultResources, log logr.Logger) {
+	// Per-entry checks: typo / unparseable / non-positive.
+	checkEntries := func(path string, m map[string]string) {
+		for k, v := range m {
+			if v == "" {
+				continue
+			}
+			if _, err := validateProxyResourceEntry(k, v); err != nil {
+				log.Error(err, "ignoring invalid entry in global proxy resource config",
+					"path", path, "resource", k, "value", v)
+			}
+		}
+	}
+	checkEntries("networkProxy.defaultResources.nonMitm.requests", dr.NonMITM.Requests)
+	checkEntries("networkProxy.defaultResources.nonMitm.limits", dr.NonMITM.Limits)
+	checkEntries("networkProxy.defaultResources.mitm.requests", dr.MITM.Requests)
+	checkEntries("networkProxy.defaultResources.mitm.limits", dr.MITM.Limits)
+
+	// Per-tier check: within a tier, a valid limit must not be below its valid
+	// request. We only compare entries that are themselves valid (invalid ones
+	// are already reported above and dropped on read).
+	warnLimitBelowRequest := func(tier string, requests, limits map[string]string) {
+		for name, reqStr := range requests {
+			limStr, ok := limits[name]
+			if !ok {
+				continue
+			}
+			reqQ, reqErr := validateProxyResourceEntry(name, reqStr)
+			limQ, limErr := validateProxyResourceEntry(name, limStr)
+			if reqErr != nil || limErr != nil {
+				continue
+			}
+			if limQ.Cmp(reqQ) < 0 {
+				log.Error(
+					fmt.Errorf("limits.%s (%s) < requests.%s (%s)", name, limStr, name, reqStr),
+					"global proxy resource config has a limit below its request; "+
+						"the kube-apiserver will reject the sidecar Pod unless a per-policy override corrects it",
+					"tier", tier, "resource", name)
+			}
+		}
+	}
+	warnLimitBelowRequest("non-mitm", dr.NonMITM.Requests, dr.NonMITM.Limits)
+	warnLimitBelowRequest("mitm", dr.MITM.Requests, dr.MITM.Limits)
 }
 
 // applyConfigMap extracts the embedded document from a ConfigMap and swaps it
@@ -219,6 +350,68 @@ func StartDynamicConfigInformer(cmInformer coreinformer.ConfigMapInformer, log l
 // snapshot. Intended for read-only inspection/tests.
 func GetDynamicConfig() DynamicConfig {
 	return currentDynamicConfig.get()
+}
+
+// SetDynamicConfigForTest overrides the process-wide dynamic config snapshot and
+// returns a function that restores the built-in defaults. It exists so tests in
+// other packages (e.g. the injection chain) can exercise config-dependent
+// behaviour. Production code must never call it: the ConfigMap informer is the
+// sole writer of the snapshot at runtime.
+func SetDynamicConfigForTest(cfg DynamicConfig) (restore func()) {
+	currentDynamicConfig.set(cfg)
+	return resetDynamicConfigToDefault
+}
+
+// GetNetworkProxyDefaultResources returns the cluster-global proxy sidecar
+// resource defaults from the current dynamic config snapshot, as two ready-to-
+// merge corev1.ResourceRequirements: nonMITM and mitm. Only successfully parsed
+// quantities are populated; unset or invalid values are omitted so callers can
+// overlay them field-by-field on top of the built-in defaults. When nothing is
+// configured, both returned values are empty (nil maps), which makes the merge
+// a no-op and preserves the built-in defaults.
+func GetNetworkProxyDefaultResources() (nonMITM, mitm corev1.ResourceRequirements) {
+	dr := currentDynamicConfig.get().NetworkProxy.DefaultResources
+	nonMITM = corev1.ResourceRequirements{
+		Requests: parseResourceList(dr.NonMITM.Requests),
+		Limits:   parseResourceList(dr.NonMITM.Limits),
+	}
+	mitm = corev1.ResourceRequirements{
+		Requests: parseResourceList(dr.MITM.Requests),
+		Limits:   parseResourceList(dr.MITM.Limits),
+	}
+	return nonMITM, mitm
+}
+
+// parseResourceList converts a map of quantity strings (keyed by resource name)
+// into a corev1.ResourceList, skipping empty or invalid entries (unknown
+// resource name, unparseable quantity, or non-positive value). It returns nil
+// when nothing valid is present so the result overlays cleanly (a nil map
+// contributes no fields to the merge). The per-entry rule is shared with the
+// load-time warner via validateProxyResourceEntry, so what is dropped here is
+// exactly what gets warned about at load time.
+func parseResourceList(m map[string]string) corev1.ResourceList {
+	if len(m) == 0 {
+		return nil
+	}
+	rl := corev1.ResourceList{}
+	for k, v := range m {
+		if v == "" {
+			continue
+		}
+		q, err := validateProxyResourceEntry(k, v)
+		if err != nil {
+			// Invalid entries are dropped here and warned about at load time
+			// (warnInvalidProxyResourceValues), so a typo/negative/zero degrades
+			// to the built-in default for that field instead of producing a
+			// bogus sidecar resource or breaking admission.
+			continue
+		}
+		rl[corev1.ResourceName(k)] = q
+	}
+	if len(rl) == 0 {
+		return nil
+	}
+	return rl
 }
 
 // IsMicroVMPod reports whether a Pod with the given template labels, annotations

--- a/internal/config/networkproxy_resources_test.go
+++ b/internal/config/networkproxy_resources_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// quantityEqual asserts that a ResourceList entry equals the expected quantity
+// string, reporting a helpful message on mismatch.
+func quantityEqual(t *testing.T, rl corev1.ResourceList, name corev1.ResourceName, want string) {
+	t.Helper()
+	got, ok := rl[name]
+	assert.Assert(t, ok, "resource %s should be present", name)
+	assert.Assert(t, got.Cmp(resource.MustParse(want)) == 0,
+		"resource %s = %s, want %s", name, got.String(), want)
+}
+
+func TestParseDynamicConfig_NetworkProxyDefaultResources(t *testing.T) {
+	raw := `
+networkProxy:
+  defaultResources:
+    nonMitm:
+      requests:
+        cpu: 60m
+        memory: 80Mi
+      limits:
+        cpu: 600m
+    mitm:
+      requests:
+        cpu: 120m
+      limits:
+        cpu: 1200m
+        memory: 640Mi
+`
+	cfg := parseDynamicConfig(raw, logr.Discard())
+	dr := cfg.NetworkProxy.DefaultResources
+	assert.Equal(t, dr.NonMITM.Requests["cpu"], "60m")
+	assert.Equal(t, dr.NonMITM.Requests["memory"], "80Mi")
+	assert.Equal(t, dr.NonMITM.Limits["cpu"], "600m")
+	assert.Equal(t, dr.MITM.Requests["cpu"], "120m")
+	assert.Equal(t, dr.MITM.Limits["cpu"], "1200m")
+	assert.Equal(t, dr.MITM.Limits["memory"], "640Mi")
+}
+
+func TestGetNetworkProxyDefaultResources_Empty(t *testing.T) {
+	resetDynamicConfigToDefault()
+	t.Cleanup(resetDynamicConfigToDefault)
+
+	nonMITM, mitm := GetNetworkProxyDefaultResources()
+	// Nothing configured: all resource lists are nil so the merge is a no-op.
+	assert.Assert(t, nonMITM.Requests == nil, "nonMITM requests should be nil when unconfigured")
+	assert.Assert(t, nonMITM.Limits == nil, "nonMITM limits should be nil when unconfigured")
+	assert.Assert(t, mitm.Requests == nil, "mitm requests should be nil when unconfigured")
+	assert.Assert(t, mitm.Limits == nil, "mitm limits should be nil when unconfigured")
+}
+
+func TestGetNetworkProxyDefaultResources_PartialAndTiers(t *testing.T) {
+	withConfig(t, DynamicConfig{
+		NetworkProxy: NetworkProxyDynamicConfig{
+			DefaultResources: ProxyDefaultResources{
+				NonMITM: ProxyResourceTier{
+					Requests: map[string]string{"cpu": "60m"}, // memory intentionally absent
+					Limits:   map[string]string{"cpu": "600m", "memory": "300Mi"},
+				},
+				MITM: ProxyResourceTier{
+					Requests: map[string]string{"memory": "200Mi"},
+					Limits:   map[string]string{"cpu": "1500m"},
+				},
+			},
+		},
+	})
+
+	nonMITM, mitm := GetNetworkProxyDefaultResources()
+
+	// Non-MITM tier: only configured leaves are present.
+	quantityEqual(t, nonMITM.Requests, corev1.ResourceCPU, "60m")
+	_, hasMem := nonMITM.Requests[corev1.ResourceMemory]
+	assert.Assert(t, !hasMem, "unconfigured nonMITM requests.memory should be absent")
+	quantityEqual(t, nonMITM.Limits, corev1.ResourceCPU, "600m")
+	quantityEqual(t, nonMITM.Limits, corev1.ResourceMemory, "300Mi")
+
+	// MITM tier is independent of the non-MITM tier.
+	quantityEqual(t, mitm.Requests, corev1.ResourceMemory, "200Mi")
+	_, hasCPU := mitm.Requests[corev1.ResourceCPU]
+	assert.Assert(t, !hasCPU, "unconfigured mitm requests.cpu should be absent")
+	quantityEqual(t, mitm.Limits, corev1.ResourceCPU, "1500m")
+}
+
+func TestGetNetworkProxyDefaultResources_InvalidValuesDropped(t *testing.T) {
+	withConfig(t, DynamicConfig{
+		NetworkProxy: NetworkProxyDynamicConfig{
+			DefaultResources: ProxyDefaultResources{
+				NonMITM: ProxyResourceTier{
+					Requests: map[string]string{"cpu": "not-a-quantity", "memory": "80Mi"},
+				},
+			},
+		},
+	})
+
+	nonMITM, _ := GetNetworkProxyDefaultResources()
+	// The invalid cpu is dropped; the valid memory survives.
+	_, hasCPU := nonMITM.Requests[corev1.ResourceCPU]
+	assert.Assert(t, !hasCPU, "invalid cpu quantity should be dropped")
+	quantityEqual(t, nonMITM.Requests, corev1.ResourceMemory, "80Mi")
+}
+
+func TestGetNetworkProxyDefaultResources_NegativeAndZeroDropped(t *testing.T) {
+	withConfig(t, DynamicConfig{
+		NetworkProxy: NetworkProxyDynamicConfig{
+			DefaultResources: ProxyDefaultResources{
+				// cpu is negative and memory is zero: both parse as valid
+				// quantities but are meaningless as sidecar resources, so both
+				// must be dropped (field falls back to the built-in default).
+				NonMITM: ProxyResourceTier{
+					Requests: map[string]string{"cpu": "-5m", "memory": "0"},
+					Limits:   map[string]string{"cpu": "500m"},
+				},
+			},
+		},
+	})
+
+	nonMITM, _ := GetNetworkProxyDefaultResources()
+	_, hasCPU := nonMITM.Requests[corev1.ResourceCPU]
+	assert.Assert(t, !hasCPU, "negative cpu request should be dropped")
+	_, hasMem := nonMITM.Requests[corev1.ResourceMemory]
+	assert.Assert(t, !hasMem, "zero memory request should be dropped")
+	// A valid entry in the same block still survives.
+	quantityEqual(t, nonMITM.Limits, corev1.ResourceCPU, "500m")
+}
+
+func TestGetNetworkProxyDefaultResources_UnknownResourceNameDropped(t *testing.T) {
+	withConfig(t, DynamicConfig{
+		NetworkProxy: NetworkProxyDynamicConfig{
+			DefaultResources: ProxyDefaultResources{
+				// "cpuu" is a typo: a valid quantity attached to an unknown
+				// resource name. It must be dropped rather than injected as a
+				// bogus resource, and the real cpu keeps falling back.
+				NonMITM: ProxyResourceTier{
+					Requests: map[string]string{"cpuu": "100m", "memory": "80Mi"},
+				},
+			},
+		},
+	})
+
+	nonMITM, _ := GetNetworkProxyDefaultResources()
+	_, hasTypo := nonMITM.Requests[corev1.ResourceName("cpuu")]
+	assert.Assert(t, !hasTypo, "unknown resource name should be dropped")
+	_, hasCPU := nonMITM.Requests[corev1.ResourceCPU]
+	assert.Assert(t, !hasCPU, "the real cpu was never set, so it must be absent")
+	quantityEqual(t, nonMITM.Requests, corev1.ResourceMemory, "80Mi")
+}
+
+func TestValidateProxyResourceEntry(t *testing.T) {
+	cases := []struct {
+		name, value string
+		wantErr     bool
+	}{
+		{"cpu", "100m", false},
+		{"memory", "64Mi", false},
+		{"cpu", "-5m", true},   // negative
+		{"memory", "0", true},  // zero
+		{"cpu", "abc", true},   // unparseable
+		{"cpuu", "100m", true}, // unknown resource name
+	}
+	for _, c := range cases {
+		_, err := validateProxyResourceEntry(c.name, c.value)
+		if c.wantErr {
+			assert.Assert(t, err != nil, "%s=%s should be rejected", c.name, c.value)
+		} else {
+			assert.NilError(t, err, "%s=%s should be accepted", c.name, c.value)
+		}
+	}
+}
+
+// TestWarnInvalidProxyResourceValues_LimitBelowRequest exercises the load-time
+// warner directly to ensure it does not panic and handles the limit<request and
+// invalid-entry paths across both tiers. It is a smoke test: the warner only
+// logs, so we assert it runs cleanly against a config that trips every branch.
+func TestWarnInvalidProxyResourceValues_LimitBelowRequest(t *testing.T) {
+	dr := ProxyDefaultResources{
+		NonMITM: ProxyResourceTier{
+			Requests: map[string]string{"cpu": "500m"},
+			Limits:   map[string]string{"cpu": "200m"}, // limit < request (non-mitm)
+		},
+		MITM: ProxyResourceTier{
+			Requests: map[string]string{"memory": "256Mi", "cpuu": "1"}, // typo entry
+			Limits:   map[string]string{"memory": "128Mi"},              // limit < request (mitm)
+		},
+	}
+	// Must not panic; all findings go to the logger.
+	warnInvalidProxyResourceValues(dr, logr.Discard())
+}

--- a/internal/policy/proxy_resources.go
+++ b/internal/policy/proxy_resources.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
+	varmorconfig "github.com/bytedance/vArmor/internal/config"
 )
 
 // DefaultProxyResources returns the built-in resource requirements for the
@@ -63,25 +64,48 @@ func DefaultProxyResources(mitmEnabled bool) corev1.ResourceRequirements {
 }
 
 // ResolveProxyResources computes the final resource requirements for the proxy
-// sidecar container by merging user-specified overrides on top of the built-in
-// defaults. The merge is field-level: only the resource types (cpu, memory)
-// explicitly specified in the override are applied; all others retain the
-// default values.
+// sidecar container using a three-layer, field-level merge chain. Each leaf
+// scalar (requests.cpu, requests.memory, limits.cpu, limits.memory) is resolved
+// independently: a value from a higher-priority layer wins, otherwise the value
+// falls through to the next layer. This means a partially-specified global
+// config or per-policy override only overrides the fields it sets; every other
+// field keeps falling back to the built-in default.
 //
-// Merge chain:
+// Merge chain (highest priority first):
 //
-//	Policy override > Built-in defaults (selected by mitmEnabled)
+//	Per-policy override
+//	  > Cluster-global config (varmor-config ConfigMap, MITM-aware tier)
+//	    > Built-in defaults (selected by mitmEnabled)
 func ResolveProxyResources(override *varmor.ProxyResourceOverride, mitmEnabled bool) corev1.ResourceRequirements {
+	// Layer 1 (lowest priority): built-in defaults.
 	result := DefaultProxyResources(mitmEnabled)
-	if override == nil {
-		return result
+
+	// Layer 2: cluster-global defaults from the varmor-config ConfigMap.
+	// GetNetworkProxyDefaultResources returns two MITM-aware tiers; pick the
+	// one matching this policy. Only non-nil resource lists overlay, and within
+	// them only present keys apply (field-level fallback).
+	nonMITMGlobal, mitmGlobal := varmorconfig.GetNetworkProxyDefaultResources()
+	global := nonMITMGlobal
+	if mitmEnabled {
+		global = mitmGlobal
 	}
-	for k, v := range override.Requests {
+	for k, v := range global.Requests {
 		result.Requests[k] = v
 	}
-	for k, v := range override.Limits {
+	for k, v := range global.Limits {
 		result.Limits[k] = v
 	}
+
+	// Layer 3 (highest priority): per-policy override.
+	if override != nil {
+		for k, v := range override.Requests {
+			result.Requests[k] = v
+		}
+		for k, v := range override.Limits {
+			result.Limits[k] = v
+		}
+	}
+
 	return result
 }
 

--- a/internal/policy/proxy_resources_test.go
+++ b/internal/policy/proxy_resources_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
+	varmorconfig "github.com/bytedance/vArmor/internal/config"
+)
+
+func mustQ(t *testing.T, rl corev1.ResourceList, name corev1.ResourceName, want string) {
+	t.Helper()
+	got, ok := rl[name]
+	assert.Assert(t, ok, "resource %s should be present", name)
+	assert.Assert(t, got.Cmp(resource.MustParse(want)) == 0,
+		"resource %s = %s, want %s", name, got.String(), want)
+}
+
+// TestResolveProxyResources_BuiltinOnly verifies that with no global config and
+// no per-policy override, the built-in MITM-aware defaults are returned.
+func TestResolveProxyResources_BuiltinOnly(t *testing.T) {
+	// Non-MITM built-in defaults.
+	r := ResolveProxyResources(nil, false)
+	mustQ(t, r.Requests, corev1.ResourceCPU, "50m")
+	mustQ(t, r.Requests, corev1.ResourceMemory, "64Mi")
+	mustQ(t, r.Limits, corev1.ResourceCPU, "500m")
+	mustQ(t, r.Limits, corev1.ResourceMemory, "256Mi")
+
+	// MITM built-in defaults.
+	rm := ResolveProxyResources(nil, true)
+	mustQ(t, rm.Requests, corev1.ResourceCPU, "100m")
+	mustQ(t, rm.Requests, corev1.ResourceMemory, "128Mi")
+	mustQ(t, rm.Limits, corev1.ResourceCPU, "1000m")
+	mustQ(t, rm.Limits, corev1.ResourceMemory, "512Mi")
+}
+
+// TestResolveProxyResources_GlobalOverlaysFieldLevel verifies the middle layer:
+// global config overrides only the fields it sets; unset fields keep the
+// built-in defaults.
+func TestResolveProxyResources_GlobalOverlaysFieldLevel(t *testing.T) {
+	restore := varmorconfig.SetDynamicConfigForTest(varmorconfig.DynamicConfig{
+		NetworkProxy: varmorconfig.NetworkProxyDynamicConfig{
+			DefaultResources: varmorconfig.ProxyDefaultResources{
+				NonMITM: varmorconfig.ProxyResourceTier{
+					Requests: map[string]string{"cpu": "70m"},      // only cpu; memory falls back
+					Limits:   map[string]string{"memory": "300Mi"}, // only memory; cpu falls back
+				},
+			},
+		},
+	})
+	defer restore()
+
+	r := ResolveProxyResources(nil, false)
+	mustQ(t, r.Requests, corev1.ResourceCPU, "70m")     // from global
+	mustQ(t, r.Requests, corev1.ResourceMemory, "64Mi") // built-in fallback
+	mustQ(t, r.Limits, corev1.ResourceCPU, "500m")      // built-in fallback
+	mustQ(t, r.Limits, corev1.ResourceMemory, "300Mi")  // from global
+}
+
+// TestResolveProxyResources_MITMTierSelected verifies that the MITM tier of the
+// global config is applied only for MITM policies, and the non-MITM tier only
+// for non-MITM policies.
+func TestResolveProxyResources_MITMTierSelected(t *testing.T) {
+	restore := varmorconfig.SetDynamicConfigForTest(varmorconfig.DynamicConfig{
+		NetworkProxy: varmorconfig.NetworkProxyDynamicConfig{
+			DefaultResources: varmorconfig.ProxyDefaultResources{
+				NonMITM: varmorconfig.ProxyResourceTier{
+					Requests: map[string]string{"cpu": "70m"},
+				},
+				MITM: varmorconfig.ProxyResourceTier{
+					Requests: map[string]string{"cpu": "200m"},
+				},
+			},
+		},
+	})
+	defer restore()
+
+	// Non-MITM policy sees the non-MITM tier only.
+	r := ResolveProxyResources(nil, false)
+	mustQ(t, r.Requests, corev1.ResourceCPU, "70m")
+
+	// MITM policy sees the MITM tier only (non-MITM tier's cpu must NOT leak in).
+	rm := ResolveProxyResources(nil, true)
+	mustQ(t, rm.Requests, corev1.ResourceCPU, "200m")
+	mustQ(t, rm.Requests, corev1.ResourceMemory, "128Mi") // MITM built-in fallback
+}
+
+// TestResolveProxyResources_OverrideWinsOverGlobal verifies the full three-layer
+// precedence: per-policy override > global config > built-in default.
+func TestResolveProxyResources_OverrideWinsOverGlobal(t *testing.T) {
+	restore := varmorconfig.SetDynamicConfigForTest(varmorconfig.DynamicConfig{
+		NetworkProxy: varmorconfig.NetworkProxyDynamicConfig{
+			DefaultResources: varmorconfig.ProxyDefaultResources{
+				NonMITM: varmorconfig.ProxyResourceTier{
+					Requests: map[string]string{"cpu": "70m", "memory": "100Mi"},
+					Limits:   map[string]string{"cpu": "700m"},
+				},
+			},
+		},
+	})
+	defer restore()
+
+	override := &varmor.ProxyResourceOverride{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("90m"), // beats global 70m
+		},
+	}
+
+	r := ResolveProxyResources(override, false)
+	mustQ(t, r.Requests, corev1.ResourceCPU, "90m")      // override wins
+	mustQ(t, r.Requests, corev1.ResourceMemory, "100Mi") // global (no override)
+	mustQ(t, r.Limits, corev1.ResourceCPU, "700m")       // global (no override)
+	mustQ(t, r.Limits, corev1.ResourceMemory, "256Mi")   // built-in fallback
+}
+
+// TestResolveProxyResources_EmptyGlobalIsNoOp verifies that an empty global
+// config leaves the built-in + override behaviour unchanged (backward compat).
+func TestResolveProxyResources_EmptyGlobalIsNoOp(t *testing.T) {
+	restore := varmorconfig.SetDynamicConfigForTest(varmorconfig.DynamicConfig{})
+	defer restore()
+
+	override := &varmor.ProxyResourceOverride{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+	r := ResolveProxyResources(override, false)
+	mustQ(t, r.Requests, corev1.ResourceCPU, "50m")     // built-in
+	mustQ(t, r.Requests, corev1.ResourceMemory, "64Mi") // built-in
+	mustQ(t, r.Limits, corev1.ResourceCPU, "500m")      // built-in
+	mustQ(t, r.Limits, corev1.ResourceMemory, "1Gi")    // override
+}

--- a/internal/webhooks/audit_mutation_test.go
+++ b/internal/webhooks/audit_mutation_test.go
@@ -132,3 +132,61 @@ func Test_buildNetworkProxyPatch_MicroVM(t *testing.T) {
 	assert.Assert(t, strings.Contains(patch, `"securityContext": {"runAsUser": 0}`),
 		"micro-VM patch should still start the sidecar as root")
 }
+
+// Test_buildNetworkProxyPatch_GlobalDefaultResources asserts that cluster-global
+// sidecar resource defaults from the varmor-config ConfigMap flow through the
+// injection chain into the sidecar container's "resources" field, and that the
+// merge is field-level: a global value overrides its field while unset fields
+// keep the built-in defaults.
+func Test_buildNetworkProxyPatch_GlobalDefaultResources(t *testing.T) {
+	restore := varmorconfig.SetDynamicConfigForTest(varmorconfig.DynamicConfig{
+		NetworkProxy: varmorconfig.NetworkProxyDynamicConfig{
+			DefaultResources: varmorconfig.ProxyDefaultResources{
+				NonMITM: varmorconfig.ProxyResourceTier{
+					Requests: map[string]string{"cpu": "70m"},      // memory falls back to built-in 64Mi
+					Limits:   map[string]string{"memory": "300Mi"}, // cpu falls back to built-in 500m
+				},
+			},
+		},
+	})
+	defer restore()
+
+	patch := buildNetworkProxyPatch("varmor-testns-test", varmorpolicy.AuditPolicyIdentity{Kind: "VarmorPolicy", Name: "test", Namespace: "testns"}, true, nil, false)
+
+	// Global-configured fields land in the sidecar resources.
+	assert.Assert(t, strings.Contains(patch, `"cpu":"70m"`),
+		"sidecar resources should carry the global requests.cpu override")
+	assert.Assert(t, strings.Contains(patch, `"memory":"300Mi"`),
+		"sidecar resources should carry the global limits.memory override")
+	// Unset fields keep the built-in non-MITM defaults.
+	assert.Assert(t, strings.Contains(patch, `"memory":"64Mi"`),
+		"sidecar resources should keep the built-in requests.memory default")
+	assert.Assert(t, strings.Contains(patch, `"cpu":"500m"`),
+		"sidecar resources should keep the built-in limits.cpu default")
+}
+
+// Test_buildNetworkProxyPatch_GlobalMITMTier asserts that the MITM tier of the
+// global config is selected for MITM policies.
+func Test_buildNetworkProxyPatch_GlobalMITMTier(t *testing.T) {
+	restore := varmorconfig.SetDynamicConfigForTest(varmorconfig.DynamicConfig{
+		NetworkProxy: varmorconfig.NetworkProxyDynamicConfig{
+			DefaultResources: varmorconfig.ProxyDefaultResources{
+				MITM: varmorconfig.ProxyResourceTier{
+					Limits: map[string]string{"cpu": "1500m"},
+				},
+			},
+		},
+	})
+	defer restore()
+
+	proxyConfig := &varmor.NetworkProxyConfig{
+		MITM: &varmor.MITMConfig{Domains: []string{"example.com"}},
+	}
+	patch := buildNetworkProxyPatch("varmor-testns-test", varmorpolicy.AuditPolicyIdentity{Kind: "VarmorPolicy", Name: "test", Namespace: "testns"}, true, proxyConfig, false)
+
+	// The MITM-tier global override lands; other fields keep MITM built-in defaults.
+	assert.Assert(t, strings.Contains(patch, `"cpu":"1500m"`),
+		"MITM sidecar resources should carry the global mitm.limits.cpu override")
+	assert.Assert(t, strings.Contains(patch, `"memory":"512Mi"`),
+		"MITM sidecar resources should keep the built-in mitm limits.memory default")
+}

--- a/manifests/varmor/templates/configmap.yaml
+++ b/manifests/varmor/templates/configmap.yaml
@@ -38,3 +38,47 @@ data:
         - key: {{ .key | quote }}
           value: {{ .value | quote }}
         {{- end }}
+    # networkProxy holds cluster-wide defaults for the NetworkProxy (Envoy)
+    # sidecar. Currently it carries defaultResources, the cluster-level default
+    # resource requests/limits for the injected sidecar container. The injector
+    # resolves the final resources with a three-layer, field-level merge chain:
+    # per-policy override > this cluster-global config > built-in defaults. Each
+    # leaf value (requests.cpu/memory, limits.cpu/memory) falls back
+    # independently, so a partial config only overrides the fields it sets.
+    # Two independent, MITM-aware tiers are supported: nonMitm applies to
+    # non-MITM sidecars, while mitm applies to MITM sidecars (which run heavier
+    # due to double TLS handshakes). Any block left empty is skipped entirely,
+    # keeping the built-in defaults for that tier/field. The tiers are
+    # independent, NOT inherited: a MITM sidecar reads ONLY the mitm tier and a
+    # non-MITM sidecar reads ONLY the nonMitm tier, so each tier must be set
+    # explicitly to change it.
+    # Invalid entries (unknown resource name, unparseable quantity, non-positive
+    # value) are ignored and logged by the manager at load time, as is a limit
+    # set below its request in the same tier. Note the tier keys must be spelled
+    # EXACTLY "nonMitm" and "mitm": a misspelled tier key is silently ignored
+    # (that tier falls back to the built-in defaults) with no warning, because
+    # only the entries inside a tier are validated, not the tier key itself.
+    networkProxy:
+      defaultResources:
+        {{- if or .Values.dynamicConfig.networkProxy.defaultResources.nonMitm.requests .Values.dynamicConfig.networkProxy.defaultResources.nonMitm.limits }}
+        nonMitm:
+          {{- with .Values.dynamicConfig.networkProxy.defaultResources.nonMitm.requests }}
+          requests:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dynamicConfig.networkProxy.defaultResources.nonMitm.limits }}
+          limits:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if or .Values.dynamicConfig.networkProxy.defaultResources.mitm.requests .Values.dynamicConfig.networkProxy.defaultResources.mitm.limits }}
+        mitm:
+          {{- with .Values.dynamicConfig.networkProxy.defaultResources.mitm.requests }}
+          requests:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dynamicConfig.networkProxy.defaultResources.mitm.limits }}
+          limits:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}

--- a/manifests/varmor/values.yaml
+++ b/manifests/varmor/values.yaml
@@ -110,6 +110,71 @@ dynamicConfig:
     - key: alibabacloud.com/eci
       value: "true"
 
+  # networkProxy holds cluster-wide defaults for the NetworkProxy (Envoy) sidecar.
+  # defaultResources sets the cluster-level default resource requests/limits for
+  # the injected sidecar container. The injector resolves the final resources with
+  # a three-layer, field-level merge chain: per-policy override > this cluster-
+  # global config > built-in defaults. Each leaf value (requests.cpu/memory,
+  # limits.cpu/memory) falls back independently, so a partial config below only
+  # overrides the fields it sets; everything unset keeps the built-in defaults.
+  #
+  # Two independent, MITM-aware tiers are supported: nonMitm applies to non-MITM
+  # sidecars; mitm applies to MITM sidecars, which run heavier due to double TLS
+  # handshakes. Leave a block empty (as shipped) to keep the built-in defaults
+  # for that tier.
+  #
+  # IMPORTANT: the two tiers are independent, NOT inherited. A MITM sidecar reads
+  # ONLY the mitm tier and a non-MITM sidecar reads ONLY the nonMitm tier. So to
+  # raise resources for MITM workloads you must set the mitm block explicitly;
+  # setting only nonMitm leaves MITM sidecars on their built-in defaults, and
+  # vice versa.
+  #
+  # IMPORTANT: the tier keys must be spelled EXACTLY "nonMitm" and "mitm" (the
+  # embedded config is parsed leniently). A misspelled tier key (e.g. "nonMITM",
+  # "non-mitm", "Mitm") is silently ignored -- that tier falls back to the
+  # built-in defaults with NO warning, since only the entries INSIDE a tier are
+  # validated at load time, not the tier key itself.
+  #
+  # IMPORTANT: always quote quantities as strings (e.g. cpu: "500m", memory:
+  # "256Mi"). An unquoted bare number is parsed by YAML as an integer, so
+  # `memory: 100` means 100 BYTES, not 100Mi. Unquoted suffixed values (500m,
+  # 256Mi) are fine because YAML already reads them as strings, but quoting
+  # everything is the safe habit.
+  #
+  # Invalid entries are ignored (that field falls back to its built-in default)
+  # and logged by the manager at load time: an unknown resource name (only cpu
+  # and memory are supported), an unparseable quantity, or a non-positive value
+  # (zero or negative). A limit set below its request in the same tier is also
+  # warned about (the kube-apiserver would otherwise reject the sidecar Pod).
+  #
+  # Built-in defaults for reference:
+  #   non-MITM  requests: cpu 50m,  memory 64Mi   limits: cpu 500m,  memory 256Mi
+  #   MITM      requests: cpu 100m, memory 128Mi  limits: cpu 1000m, memory 512Mi
+  networkProxy:
+    defaultResources:
+      # Non-MITM sidecar defaults. Example (quote every quantity):
+      #   nonMitm:
+      #     requests:
+      #       cpu: "50m"
+      #       memory: "64Mi"
+      #     limits:
+      #       cpu: "500m"
+      #       memory: "256Mi"
+      nonMitm:
+        requests: {}
+        limits: {}
+      # MITM sidecar defaults. Example (quote every quantity):
+      #   mitm:
+      #     requests:
+      #       cpu: "100m"
+      #       memory: "128Mi"
+      #     limits:
+      #       cpu: "1000m"
+      #       memory: "512Mi"
+      mitm:
+        requests: {}
+        limits: {}
+
 image:
   registry: ""
   namespace: varmor


### PR DESCRIPTION
## Summary

Introduce cluster-wide default resource requirements for the NetworkProxy Envoy sidecar, configurable through the `varmor-config` ConfigMap. An administrator can now tune sidecar CPU/memory once at the cluster level instead of editing every policy, while per-policy overrides and the built-in safety defaults both keep working unchanged.

Resource resolution follows a three-layer, field-level merge chain: **per-policy override > global ConfigMap config > built-in defaults**.

## Problem

The NetworkProxy enforcer injects an Envoy sidecar whose resource requests/limits could only come from two places: a hardcoded built-in default, or a per-policy override on each `VarmorPolicy`/`VarmorClusterPolicy`. There was no cluster-level knob in between.

In practice this means an administrator who wants a different baseline (e.g. larger memory limits for a busy cluster) has to edit and maintain the override on every single policy. There is no single place to set an org-wide default, and the built-in numbers are only tunable by rebuilding the manager.

## Solution Overview

Add a `networkProxy.defaultResources` section to the `varmor-config` ConfigMap, consumed through the existing dynamic-config informer (hot-reloaded, RWMutex-guarded snapshot, fall back to built-in on absence/parse failure).

The global config is split into **two independent tiers** — `nonMitm` and `mitm` — mirroring the built-in defaults, because MITM sidecars run heavier (they terminate and re-originate TLS, i.e. double handshakes) than non-MITM ones. A MITM sidecar reads **only** the `mitm` tier and a non-MITM sidecar reads **only** the `nonMitm` tier; there is **no inheritance** between them. The two tiers are symmetric so there is no hidden precedence to reason about.

Resolution merges at the individual resource-field level, so a global config that sets only `memory` still inherits the built-in `cpu`, and a per-policy override that sets only `cpu` still inherits the global `memory`.

## Key Changes

**Dynamic config parsing & validation** (`internal/config/dynamic.go`)
- Parse `networkProxy.defaultResources.{nonMitm,mitm}.{requests,limits}`.
- Per-entry validation via `validateProxyResourceEntry`: the resource name must be known (`cpu`/`memory`), the quantity must be parseable by `resource.ParseQuantity`, and it must be strictly positive (`Sign() > 0`, so negative and zero values are rejected — `ParseQuantity` accepts both without error).
- Invalid entries are **dropped with a warning** at load time and fall back to the built-in default for that field; the read path drops exactly the same entries, so warnings and behavior stay in lockstep.
- `GetNetworkProxyDefaultResources()` returns the two tiers as `corev1.ResourceRequirements`.

**Three-layer merge** (`internal/policy/proxy_resources.go`)
- `ResolveProxyResources(override, mitmEnabled)` starts from the built-in tier, overlays the global tier selected by `mitmEnabled`, then overlays the per-policy override — all field-by-field. The merge is nil-safe and non-aliasing (fresh maps, ranging over a nil tier is a no-op).

**Helm** (`manifests/varmor/templates/configmap.yaml`, `values.yaml`)
- Render the symmetric `nonMitm` / `mitm` blocks in the ConfigMap template.
- Document the tiers, the YAML bare-number-is-**bytes** trap (`memory: 100` = 100 bytes, not 100Mi), and that a **misspelled tier key is silently ignored** (that tier falls back to the built-in defaults with no warning, because the underlying YAML decode is lenient).

**Tests**
- Cover parsing, per-entry validation (unknown name / unparseable / negative / zero), tier selection by `mitmEnabled`, merge precedence (override > global > built-in), empty-global no-op, and the webhook patch output.

## Built-in Default Tiers (unchanged fallback)

| Tier | Requests | Limits |
|---|---|---|
| non-MITM | cpu 50m, memory 64Mi | cpu 500m, memory 256Mi |
| MITM | cpu 100m, memory 128Mi | cpu 1000m, memory 512Mi |

## Files Changed

| Area | Files |
|---|---|
| Dynamic config / validation | `internal/config/dynamic.go`, `internal/config/networkproxy_resources_test.go` |
| Resolution / merge | `internal/policy/proxy_resources.go`, `internal/policy/proxy_resources_test.go` |
| Webhook injection tests | `internal/webhooks/audit_mutation_test.go` |
| Helm | `manifests/varmor/templates/configmap.yaml`, `manifests/varmor/values.yaml` |

## Verification

- `gofmt -l` (clean)
- `go build ./...`
- `go vet ./...`
- `go test ./internal/config/... ./internal/policy/... ./internal/webhooks/...`
- `helm template` renders correctly for both an empty config (built-in fallback) and a populated `nonMitm`/`mitm` config.

## Notes

- The two tiers are **independent, not inherited**: a MITM sidecar never reads the `nonMitm` tier and vice-versa.
- Tier keys must be spelled **exactly** `nonMitm` and `mitm`; a misspelled tier key (e.g. `nonMITM`, `non-mitm`, `Mitm`) is silently ignored and that tier falls back to the built-in defaults with no warning.
- In YAML, a bare number for `memory` is interpreted as **bytes** — always use a unit suffix (e.g. `64Mi`).