### PR TITLE
Prepare for 0.10.4 release

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -60,13 +60,13 @@ vArmorポリシーは、**AlwaysAllow、RuntimeDefault、EnhanceProtect、Behavi
 
 ### ステップ1. チャートの取得
 ```
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 ### ステップ2. インストール
 *中国地域内では、ドメイン`elkeid-cn-beijing.cr.volces.com`を使用できます。*
 ```
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com"
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,14 +85,14 @@ The prerequisites required by different enforcers are as shown in the following 
 ### Step 1. Fetch chart
 
 ```bash
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 ### Step 2. Install
 The default configuration enables the AppArmor and Seccomp enforcers. Please refer to the documentation for more [configuration options](getting_started/installation.md#configuration).
 
 ```bash
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com"
 ```

--- a/docs/README.zh_CN.md
+++ b/docs/README.zh_CN.md
@@ -89,14 +89,14 @@ vArmor 的策略可以运行在五种模式中：*AlwaysAllow, RuntimeDefault, E
 ### 步骤 1. 拉取 chart 包
 
 ```bash
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 ### 步骤 2. 安装
 vArmor 默认支持 AppArmor 和 Seccomp enforcer。请参照 [配置选项](getting_started/installation.zh_CN.md#配置选项) 查看更多信息。
 
 ```bash
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-cn-beijing.cr.volces.com"
 ```

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -150,6 +150,55 @@ You can use the following option to change this behavior. Default: disabled.
 --set removeAllSeccompProfiles.enabled=true
 ``` 
 
+### Dynamic Configuration
+
+Besides the install-time Helm options above, vArmor ships a runtime-reloadable configuration carried by the `varmor-config` ConfigMap in vArmor's namespace. The manager watches this ConfigMap via an informer and hot-reloads changes **without a restart**. If the ConfigMap is absent or malformed, the manager falls back to the built-in defaults (which are identical to the values shipped by the chart). You can seed its initial content through the `dynamicConfig` value at install time, or edit the ConfigMap directly afterwards.
+
+```bash
+kubectl -n varmor edit configmap varmor-config
+```
+
+#### Default Resources of the NetworkProxy Sidecar
+You can set the cluster-wide default resource requests/limits for the injected NetworkProxy (Envoy) sidecar, so an administrator can tune sidecar resources once instead of setting `.spec.policy.networkProxy.resources` on every policy.
+
+The injector resolves the final resources with a three-layer, field-level merge chain, where each leaf value (`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`) falls back independently:
+
+> per-policy override (`.spec.policy.networkProxy.resources`) > this cluster-global config > built-in defaults
+
+Two independent, MITM-aware tiers are provided, because a MITM sidecar runs heavier (double TLS handshakes). A MITM sidecar reads **only** the `mitm` tier and a non-MITM sidecar reads **only** the `nonMitm` tier — the tiers are **not** inherited from each other. The built-in defaults are:
+
+| Tier | CPU requests | Memory requests | CPU limits | Memory limits |
+|------|-------------|----------------|-----------|--------------|
+| `nonMitm` | 50m | 64Mi | 500m | 256Mi |
+| `mitm` | 100m | 128Mi | 1000m | 512Mi |
+
+```bash
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.cpu="50m" \
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.memory="64Mi" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.cpu="1000m" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.memory="512Mi"
+```
+
+Notes:
+* Always quote quantities as strings (e.g. `"500m"`, `"256Mi"`). An unquoted bare number is parsed as an integer, so `memory: 100` means **100 bytes**, not 100Mi.
+* The tier keys must be spelled exactly `nonMitm` and `mitm`. A misspelled tier key is silently ignored and that tier falls back to the built-in defaults.
+* Invalid entries (an unknown resource name, an unparseable quantity, a non-positive value, or a limit set below its request in the same tier) are ignored and logged by the manager at load time; that field falls back to its built-in default.
+
+#### Micro-VM (Kata) Detection for NetworkProxy Auditing
+The NetworkProxy enforcer persists egress violation audit logs through its Envoy sidecar. Under a runc runtime, Envoy streams the records over a node-level hostPath Unix socket to the `varmor-agent` DaemonSet. Under a micro-VM runtime (kata / serverless sandbox) the sidecar runs inside a micro-VM, so that hostPath socket cannot cross the VM boundary (and is rejected at admission by some serverless providers). For such workloads vArmor omits the hostPath volume/mount and starts an in-sidecar audit sink that binds the socket in the container's own rootfs and writes the container-local `/var/log/varmor/violations.log` — producing byte-identical normalized records to the runc path.
+
+The `microVMDetection` config tells the injector which workloads run under a micro-VM runtime. A workload matches if its `runtimeClassName` is listed **OR** any annotation rule matches **OR** any label rule matches (for annotation/label rules, an empty value matches on key presence alone; a non-empty value must match exactly). The built-in defaults already cover upstream kata and the major cloud serverless runtimes:
+
+* `runtimeClassNames`: `kata`, `kata-qemu`, `kata-clh`
+* annotation: `vke.volcengine.com/burst-to-vci=enforce` (Volcengine VKE burst-to-VCI)
+* label: `alibabacloud.com/eci=true` (Alibaba Cloud ECI)
+
+To extend the rules for a custom micro-VM runtime, edit the `varmor-config` ConfigMap or set the `dynamicConfig.microVMDetection` values at install time.
+
+#### iptables Backend for NetworkProxy Traffic Redirection
+The NetworkProxy enforcer transparently redirects traffic by injecting iptables rules through an init container. Starting from the `proxyinit:v0.2` image, vArmor automatically detects the iptables backend (`legacy` vs `nft`) already in use in the target network namespace and drives the matching backend, instead of hardcoding one. This prevents traffic from being silently blackholed in shared-netns setups — for example a kata Pod whose netns is also programmed by a PaaS mesh init using the `legacy` backend. On a fresh netns it defaults to `nft` (matching prior behaviour); if both backends already carry rules it aborts with a `CONFLICT` rather than guessing. This is fully automatic and requires no configuration; just make sure the chart pulls `proxyinit:v0.2` or later.
+
+
 ## Upgrade
 
 You can use helm commands to upgrade, rollback, and perform other operations.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -19,13 +19,13 @@ vArmor can be deployed via a Helm chart which is the recommended and preferred m
 In order to install vArmor with Helm, first fetch the chart.
 
 ```
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 Then install it with helm optional [configurations](#configuration).
 
 ```
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com"
 ```
@@ -203,7 +203,7 @@ The NetworkProxy enforcer transparently redirects traffic by injecting iptables 
 
 You can use helm commands to upgrade, rollback, and perform other operations.
 ```bash
-helm upgrade varmor varmor-0.10.3.tgz \
+helm upgrade varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com" \
     --set bpfLsmEnforcer.enabled=true \

--- a/docs/getting_started/installation.zh_CN.md
+++ b/docs/getting_started/installation.zh_CN.md
@@ -150,6 +150,55 @@ vArmor 的 Agent 默认运行在独立的网络命名空间中，并在端口 `9
 --set removeAllSeccompProfiles.enabled=true
 ```
 
+### 动态配置
+
+除了上述安装时的 Helm 选项外，vArmor 还提供一份运行时可热加载的配置，承载于 vArmor 所在命名空间下的 `varmor-config` ConfigMap 中。Manager 通过 informer 监听该 ConfigMap，并在变更时**无需重启**即可热加载。如果该 ConfigMap 缺失或格式非法，Manager 会回退到内置默认值（与 Chart 随附的取值完全一致）。你可以在安装时通过 `dynamicConfig` value 设置其初始内容，也可以在安装后直接编辑该 ConfigMap。
+
+```bash
+kubectl -n varmor edit configmap varmor-config
+```
+
+#### NetworkProxy Sidecar 的默认资源
+你可以为注入的 NetworkProxy(Envoy) sidecar 设置集群级的默认资源 requests/limits，这样管理员只需配置一次，而不必在每个策略上单独设置 `.spec.policy.networkProxy.resources`。
+
+注入器采用三层、字段级的合并链来解析最终资源，其中每个叶子字段(`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`)独立回退：
+
+> 策略级覆盖(`.spec.policy.networkProxy.resources`) > 本集群级全局配置 > 内置默认值
+
+由于 MITM sidecar 负载更重(双向 TLS 握手)，配置分为两个相互独立且区分 MITM 的层级。MITM sidecar **只**读取 `mitm` 层，非 MITM sidecar **只**读取 `nonMitm` 层——两层之间**不会**相互继承。内置默认值如下：
+
+| 层级 | CPU requests | 内存 requests | CPU limits | 内存 limits |
+|------|-------------|----------------|-----------|--------------|
+| `nonMitm` | 50m | 64Mi | 500m | 256Mi |
+| `mitm` | 100m | 128Mi | 1000m | 512Mi |
+
+```bash
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.cpu="50m" \
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.memory="64Mi" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.cpu="1000m" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.memory="512Mi"
+```
+
+注意事项：
+* 资源数量务必以字符串形式加引号(如 `"500m"`、`"256Mi"`)。未加引号的裸数字会被解析为整数，因此 `memory: 100` 表示 **100 字节**，而非 100Mi。
+* 层级键名必须严格拼写为 `nonMitm` 和 `mitm`。拼写错误的层级键会被静默忽略，该层级将回退到内置默认值。
+* 非法条目(未知资源名、无法解析的数量、非正值，或同一层级内 limit 低于 request)会被忽略，并在 Manager 加载时记录日志；该字段将回退到其内置默认值。
+
+#### NetworkProxy 审计的微虚机(Kata)识别
+NetworkProxy enforcer 通过其 Envoy sidecar 持久化出口流量的违规审计日志。在 runc 运行时下，Envoy 通过节点级的 hostPath Unix socket 将记录流式发送到 `varmor-agent` DaemonSet。而在微虚机运行时(kata / Serverless 沙箱)下，sidecar 运行在微虚机内部，该 hostPath socket 无法跨越虚机边界(且部分 Serverless 厂商会在准入阶段拒绝挂载)。对于此类工作负载，vArmor 会省略 hostPath 卷/挂载，并启动一个 sidecar 内置的审计 sink，将 socket 绑定在容器自身 rootfs 中，写入容器本地的 `/var/log/varmor/violations.log`——产出与 runc 路径逐字节一致的归一化记录。
+
+`microVMDetection` 配置用于告知注入器哪些工作负载运行在微虚机运行时下。当工作负载的 `runtimeClassName` 命中列表**或**任一 annotation 规则命中**或**任一 label 规则命中时，即判定为微虚机(对于 annotation/label 规则，空值表示仅按键是否存在匹配，非空值则必须精确匹配)。内置默认值已覆盖上游 kata 及主流云厂商的 Serverless 运行时：
+
+* `runtimeClassNames`：`kata`、`kata-qemu`、`kata-clh`
+* annotation：`vke.volcengine.com/burst-to-vci=enforce`(火山引擎 VKE burst-to-VCI)
+* label：`alibabacloud.com/eci=true`(阿里云 ECI)
+
+如需为自定义的微虚机运行时扩展识别规则，可编辑 `varmor-config` ConfigMap，或在安装时设置 `dynamicConfig.microVMDetection` 的取值。
+
+#### NetworkProxy 流量重定向的 iptables 后端
+NetworkProxy enforcer 通过 init 容器注入 iptables 规则来透明地重定向流量。从 `proxyinit:v0.2` 镜像开始，vArmor 会自动探测目标网络命名空间中已在使用的 iptables 后端(`legacy` 与 `nft`)并驱动匹配的后端，而不再硬编码某一种。这可以避免在共享 netns 的场景下流量被静默丢弃——例如某个 kata Pod 的 netns 同时被使用 `legacy` 后端的 PaaS mesh init 编程。在全新的 netns 上默认使用 `nft`(与既有行为一致);若两种后端都已存在规则，则会以 `CONFLICT` 中止而非盲目猜测。该能力完全自动、无需配置，只需确保 Chart 拉取 `proxyinit:v0.2` 或更新版本即可。
+
+
 ## 更新
 
 你可以使用 helm 命令进行升级、回滚等操作。

--- a/docs/getting_started/installation.zh_CN.md
+++ b/docs/getting_started/installation.zh_CN.md
@@ -17,13 +17,13 @@
 vArmor 推荐使用 Helm chart 进行部署。通过 Helm 安装前，请先拉取 chart 包。
 
 ```
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 然后使用 helm 命令及[配置选项](#配置选项)进行安装和配置。
 
 ```
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-cn-beijing.cr.volces.com"
 ```
@@ -203,7 +203,7 @@ NetworkProxy enforcer 通过 init 容器注入 iptables 规则来透明地重定
 
 你可以使用 helm 命令进行升级、回滚等操作。
 ```bash
-helm upgrade varmor varmor-0.10.3.tgz \
+helm upgrade varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com" \
     --set bpfLsmEnforcer.enabled=true \

--- a/docs/getting_started/interface_specification.md
+++ b/docs/getting_started/interface_specification.md
@@ -254,6 +254,8 @@ Built-in defaults:
 | Non-MITM | 50m | 64Mi | 500m | 256Mi |
 | MITM | 100m | 128Mi | 1000m | 512Mi |
 
+> The resolved resources follow a three-layer, field-level merge chain: this per-policy override > the cluster-global default set in the `varmor-config` ConfigMap > the built-in defaults above. See [Default Resources of the NetworkProxy Sidecar](./installation.md#default-resources-of-the-networkproxy-sidecar) for the cluster-global configuration.
+
 ## VarmorPolicyStatus
 
 | Field | Description |

--- a/docs/getting_started/interface_specification.zh_CN.md
+++ b/docs/getting_started/interface_specification.zh_CN.md
@@ -254,6 +254,8 @@
 | 非 MITM | 50m | 64Mi | 500m | 256Mi |
 | MITM | 100m | 128Mi | 1000m | 512Mi |
 
+> 最终资源遵循三层、字段级的合并链：本策略级覆盖 > `varmor-config` ConfigMap 中设置的集群级默认值 > 上述内置默认值。集群级配置详见[NetworkProxy Sidecar 的默认资源](./installation.zh_CN.md#networkproxy-sidecar-的默认资源)。
+
 ## VarmorPolicyStatus
 
 | 字段 | 描述 |

--- a/docs/getting_started/usage_instructions.md
+++ b/docs/getting_started/usage_instructions.md
@@ -39,6 +39,7 @@ Notes:
 * Limited by the principle and performance impact of Seccomp, you can only use `auditViolations=true` and `allowViolations=true` in combination to implement the audit-only mode (observation mode) for the Seccomp enforcer when there is no policy in the BehaviorModeling mode.
 * Limited by the principle of the AppArmor LSM and Seccomp, when using the AppArmor or Seccomp enforcer, it may not be possible to associate container and Pod information for the short-lived processes.
 * The NetworkProxy enforcer reports egress traffic audit events through its Envoy sidecar. Because these events are produced by the proxy at the Pod granularity, they only carry Pod-level identity (`nodeName`, `podName`, `podNamespace`, `podUID`).
+* For the NetworkProxy enforcer, the way violation records reach `/var/log/varmor/violations.log` depends on the runtime. Under runc, the Envoy sidecar streams them to the node-level `varmor-agent`, which writes the log on the host. Under a micro-VM runtime (kata / serverless sandbox), an in-sidecar audit sink writes the log inside the container's own filesystem instead (the records are byte-identical). Whether a workload is treated as micro-VM is decided by the `microVMDetection` rules in the `varmor-config` ConfigMap; see [Micro-VM (Kata) Detection for NetworkProxy Auditing](../getting_started/installation.md#micro-vm-kata-detection-for-networkproxy-auditing).
 
 ```json
 {

--- a/docs/getting_started/usage_instructions.md
+++ b/docs/getting_started/usage_instructions.md
@@ -59,6 +59,9 @@ Notes:
   "enforcer": "BPF",
   "action": "DENIED",
   "profileName": "varmor-demo-demo-2",
+  "policyKind": "VarmorPolicy",
+  "policyName": "demo-2",
+  "policyNamespace": "demo",
   "event": {
     "operation": "File",
     "permissions": [

--- a/docs/getting_started/usage_instructions.zh_CN.md
+++ b/docs/getting_started/usage_instructions.zh_CN.md
@@ -40,6 +40,7 @@ vArmor 支持将策略对象配置为仅审计不拦截（观察模式）、拦�
 * 受限于 Seccomp 原理和性能影响，您需要组合使用 `auditViolations=true` 和 `allowViolations=true`，在没有策略处于 BehaviorModeling 模式时，实现仅审计不拦截的效果（观察模式）。
 * 受限于 AppArmor LSM 和 Seccomp 的原理，使用 AppArmor 或 Seccomp enforcer 时，可能无法关联短进程的所属容器和 Pod 信息。
 * NetworkProxy enforcer 通过其 Envoy sidecar 上报出口流量的审计事件。由于这些事件由代理在 Pod 粒度上产生，因此仅携带 Pod 级别的身份信息（`nodeName`、`podName`、`podNamespace`、`podUID`）。
+* 对于 NetworkProxy enforcer，违规记录写入 `/var/log/varmor/violations.log` 的方式取决于运行时。在 runc 下，Envoy sidecar 将记录流式发送到节点级的 `varmor-agent`，由其写入宿主机上的日志文件；在微虚机运行时(kata / Serverless 沙箱)下，则改由 sidecar 内置的审计 sink 写入容器自身文件系统中的日志文件(记录内容逐字节一致)。工作负载是否被视为微虚机，由 `varmor-config` ConfigMap 中的 `microVMDetection` 规则决定，详见[NetworkProxy 审计的微虚机(Kata)识别](../getting_started/installation.zh_CN.md#networkproxy-审计的微虚机kata识别)。
 
 ```json
 {

--- a/docs/getting_started/usage_instructions.zh_CN.md
+++ b/docs/getting_started/usage_instructions.zh_CN.md
@@ -60,6 +60,9 @@ vArmor 支持将策略对象配置为仅审计不拦截（观察模式）、拦�
   "enforcer": "BPF",
   "action": "DENIED",
   "profileName": "varmor-demo-demo-2",
+  "policyKind": "VarmorPolicy",
+  "policyName": "demo-2",
+  "policyNamespace": "demo",
   "event": {
     "operation": "File",
     "permissions": [

--- a/docs/guides/policy_advisor.md
+++ b/docs/guides/policy_advisor.md
@@ -17,6 +17,8 @@ Filter out the conflicted built-in rules with behavior data to make the policy t
 
 `policy-advisor.py AppArmor,BPF -f share-containers-pid-ns -c sys_admin,net_admin,kill -m data.json`
 
+> When matching behavior data against rules such as `disable-shell`, the advisor keys off both the executable basename and its file-extension token. So a shell recorded only as a script path (e.g. `/var/lib/cilium/bpf/init.sh`, with no `sh`/`bash`/`dash` binary) is still detected as a conflict via its `.sh` extension, and the conflicting rule is filtered out.
+
 
 ## Usage
 

--- a/docs/guides/policy_advisor.zh_CN.md
+++ b/docs/guides/policy_advisor.zh_CN.md
@@ -19,6 +19,8 @@
 
 `policy-advisor.py AppArmor,BPF -f share-containers-pid-ns -c sys_admin,net_admin,kill -m data.json`
 
+> 在将行为数据与 `disable-shell` 等规则进行匹配时，advisor 会同时依据可执行文件的 basename 及其文件扩展名进行判断。因此，即使某个 shell 仅以脚本路径的形式被记录(例如 `/var/lib/cilium/bpf/init.sh`，且没有 `sh`/`bash`/`dash` 二进制),也能通过其 `.sh` 扩展名被识别为冲突，从而过滤掉相应的冲突规则。
+
 
 ## 用法
 

--- a/website/blog/2026-08-04-0.10.4-overview/index.md
+++ b/website/blog/2026-08-04-0.10.4-overview/index.md
@@ -1,0 +1,112 @@
+---
+slug: varmor-0.10.4-new-features-overview
+title: "vArmor v0.10.4: NetworkProxy Audit Persistence, Micro-VM (Kata) Compatibility, and Production-Grade Operations"
+authors: [DannyWei]
+tags: [NewFeatures, ReleaseNotes, AIAgent, NetworkProxy]
+date: 2026-08-04T00:00
+---
+
+In vArmor v0.10.0, we introduced the [NetworkProxy enforcer](/blog/varmor-0.10.0-new-features-overview/), bringing L4/L7 network access control to Kubernetes workloads through a sidecar proxy architecture. In [v0.10.1](/blog/varmor-0.10.1-new-features-overview/), we completed the Phase 2 TLS Man-in-the-Middle (MITM) capability, upgrading it into a deep packet inspection engine that covers encrypted traffic.
+
+vArmor v0.10.4 is a **production-focused** release. We concentrated on three things: making NetworkProxy's **audit capability truly land** — audit logs that are persistent and can be correlated to workload identity; keeping vArmor working reliably in **non-standard runtimes such as micro-VMs (Kata / Serverless sandboxes)**; and lowering the operational cost of large-scale deployments through **cluster-level sidecar resource quota management** and **iptables backend auto-adaptation**. In addition, policy-advisor's conflict detection is now more precise.
+
+<!--truncate-->
+
+## Why Focus on "Audit Persistence" and "Runtime Compatibility"?
+
+Over its first two releases, the NetworkProxy enforcer solved the "can we control it" problem — from domain-level gatekeeping to deep inspection of encrypted traffic. But once users deployed it into real production clusters, especially multi-tenant environments running AI Agents, new engineering problems surfaced:
+
+- **Where did the audit logs go?** The enforcer supports the `audit` qualifier, but the audited egress traffic records need a stable, collectable landing location, and they must be attributable to the specific Pod and workload that produced them.
+- **What about micro-VM scenarios?** More and more AI Agent workloads run on Kata Containers or cloud-vendor Serverless offerings (e.g., Volcengine VCI, Alibaba Cloud ECI). The network namespaces and mount boundaries of these micro-VM runtimes differ from runc, and the original audit collection path and iptables injection method would fail — or even cause traffic to be silently dropped.
+- **How do we manage resources uniformly at scale?** MITM sidecars consume more resources than pass-through proxies, and configuring resource quotas on a per-policy basis is simply impractical at cluster scale.
+
+v0.10.4 is built around these three problems.
+
+## Persistent Egress Audit Logs for NetworkProxy
+
+The NetworkProxy enforcer reports violation audit events for egress traffic through its Envoy sidecar. v0.10.4 completes the persistence of this audit pipeline:
+
+- **Unified landing path**: All audited egress traffic records are ultimately written to the container-visible `/var/log/varmor/violations.log`, in a normalized, structured record format that log collection systems can consume uniformly.
+- **Node-level collection (runc)**: Under the runc runtime, the Envoy sidecar streams audit records over a node-level hostPath Unix Domain Socket via gRPC ALS (Access Log Service) to the `varmor-agent` DaemonSet on the node, and the agent is responsible for writing the log file. This decouples audit-data writing from collection, and consumes neither the resources nor the privileges of the application container.
+- **Pod-level identity correlation**: Since these events are produced by the proxy at Pod granularity, every record carries Pod-level identity information (`nodeName`, `podName`, `podNamespace`, `podUID`), so security teams can precisely correlate each network access to a specific workload, instead of dealing with isolated logs stripped of context.
+
+This evolves NetworkProxy's audit mode from "can record" to "can be collected by a production-grade log system and can be traced back to its source."
+
+## Micro-VM (Kata / Serverless) Audit and Traffic-Redirection Compatibility
+
+This is the core improvement in v0.10.4 for real AI Agent deployment environments. The boundaries of micro-VM runtimes (Kata, Serverless sandboxes) are fundamentally different from runc, and vArmor performs adaptive handling on two critical paths.
+
+### Audit Collection: In-Sidecar ALS Sink
+
+Under a micro-VM runtime, the sidecar runs inside the micro-VM, and the aforementioned node-level hostPath Socket **cannot cross the VM boundary** (some Serverless vendors even reject such hostPath mounts outright at admission). To address this, for workloads identified as micro-VMs, vArmor:
+
+- **Omits the hostPath volume and mount**, avoiding a rejected mount that would prevent the Pod from being scheduled;
+- **Starts an in-sidecar audit Sink**, binding the Socket inside the container's own rootfs and writing directly to the container-local `/var/log/varmor/violations.log`.
+
+Whether runc or micro-VM, the final audit records are **byte-for-byte identical**, so upper-layer collection and analysis logic need not distinguish between runtimes.
+
+### Micro-VM Detection: `microVMDetection`
+
+vArmor determines which workloads run under a micro-VM runtime via the `microVMDetection` configuration. The decision logic is: the workload's `runtimeClassName` matches the list, **or** any annotation rule matches, **or** any label rule matches (for annotation/label rules, an empty value means match by key existence only, while a non-empty value requires an exact match). The built-in defaults already cover upstream Kata and the Serverless runtimes of major cloud vendors:
+
+| Dimension | Built-in Default |
+|------|-----------|
+| `runtimeClassNames` | `kata`, `kata-qemu`, `kata-clh` |
+| annotation | `vke.volcengine.com/burst-to-vci=enforce` (Volcengine VKE burst-to-VCI) |
+| label | `alibabacloud.com/eci=true` (Alibaba Cloud ECI) |
+
+To extend the detection rules for a custom micro-VM runtime, edit the `varmor-config` ConfigMap, or set the value of `dynamicConfig.microVMDetection` at install time — **it hot-reloads with no restart required**.
+
+### Traffic Redirection: iptables Backend Auto-Adaptation
+
+The NetworkProxy enforcer injects iptables rules via an init container to transparently redirect egress traffic. Different runtimes and different infrastructures (such as certain PaaS meshes) do not use a consistent iptables backend (`legacy` vs. `nft`), and hardcoding one backend can cause traffic to be silently dropped — for example, when a Kata Pod's network namespace was already programmed by a PaaS mesh init using the `legacy` backend.
+
+Starting with the `proxyinit:v0.2` image, vArmor **automatically detects the iptables backend already in use in the target network namespace and drives the matching backend**:
+
+- On a brand-new network namespace, it defaults to `nft` (consistent with existing behavior);
+- If it detects rules already present in both backends, it aborts explicitly with `CONFLICT` rather than blindly guessing and causing a hidden failure.
+
+This capability is fully automatic and requires no configuration switch — just ensure the Chart pulls `proxyinit:v0.2` or a newer version.
+
+## Cluster-Level Sidecar Resource Quota Management
+
+In the [future roadmap of v0.10.1](/blog/varmor-0.10.1-new-features-overview/), we proposed providing cluster-level management of default sidecar resources. v0.10.4 delivers on that promise.
+
+vArmor adds a runtime hot-reloadable dynamic configuration, carried in the `varmor-config` ConfigMap in vArmor's namespace. The Manager watches this ConfigMap via an informer and hot-reloads on change **without a restart**; if the ConfigMap is missing or malformed, it falls back to the built-in defaults that are identical to the values shipped with the Chart.
+
+Administrators now only need to **configure once** to set default resource requests/limits for every NetworkProxy sidecar injected across the cluster, instead of setting `.spec.policy.networkProxy.resources` on each policy individually. The injector uses a **three-tier, field-level merge chain** to resolve the final resources, with each leaf field (`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`) falling back independently:
+
+> Policy-level override > Cluster-level global config (`varmor-config`) > Built-in default
+
+Considering that MITM sidecars carry a heavier load (bidirectional TLS handshakes), the configuration is split into two mutually independent tiers — an MITM sidecar reads only the `mitm` tier, a non-MITM sidecar reads only the `nonMitm` tier, and the two tiers do not inherit from each other. The built-in defaults are as follows:
+
+| Tier | CPU requests | Memory requests | CPU limits | Memory limits |
+|------|-------------|---------------|-----------|-------------|
+| `nonMitm` | 50m | 64Mi | 500m | 256Mi |
+| `mitm` | 100m | 128Mi | 1000m | 512Mi |
+
+```bash
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.cpu="50m" \
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.memory="64Mi" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.cpu="1000m" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.memory="512Mi"
+```
+
+Notes on usage: resource quantities must be quoted as strings (e.g., `"500m"`, `"256Mi"`); an unquoted bare number is parsed as an integer (`memory: 100` means 100 bytes, not 100Mi); tier key names must be spelled exactly as `nonMitm` and `mitm`, and misspellings are silently ignored and fall back to the built-in defaults; invalid entries (unknown resource names, unparseable quantities, non-positive values, or a limit lower than the request within the same tier) are ignored and logged when the Manager loads them.
+
+## policy-advisor: More Precise Shell-Usage Conflict Detection
+
+policy-advisor supports filtering out built-in rules that conflict with observed behavior data, making the generated policy templates more precise. v0.10.4 enhances the matching capability of rules such as `disable-shell`: when matching, the advisor now judges based on **both the basename of the executable and its file extension**.
+
+As a result, even if a shell appears in the behavior data only in the form of a script path (e.g., `/var/lib/cilium/bpf/init.sh`, without an independent `sh`/`bash`/`dash` binary execution record), it can still be correctly identified as a conflict via its `.sh` extension, filtering out the corresponding conflicting rule and avoiding the generation of a policy that would break the business.
+
+## Upgrade Notes
+
+- The NetworkProxy init container image must be `proxyinit:v0.2` or newer to enable the iptables backend auto-adaptation capability.
+- Both micro-VM detection and sidecar resource defaults are carried by the `dynamicConfig` of the `varmor-config` ConfigMap, supporting initialization at install time as well as hot updates after installation, with no restart required for changes.
+
+## Summary
+
+If v0.10.0 and v0.10.1 answered "can vArmor control an AI Agent's network behavior," then v0.10.4 answers "can vArmor do it stably, observably, and with low operational cost in a real production cluster." Through persistent audit logs with Pod-level identity correlation, adaptive compatibility for micro-VM (Kata / Serverless) runtimes on both the audit-collection and traffic-redirection paths, unified cluster-level management of sidecar resource quotas, and more precise conflict detection in policy-advisor, this release brings the NetworkProxy enforcer much closer to large-scale, multi-runtime, multi-tenant real-world deployment environments.
+
+Welcome to upgrade and try out vArmor v0.10.4, and share your feedback with us via [GitHub](https://github.com/bytedance/vArmor)! For full details, please refer to the [Release Notes](https://github.com/bytedance/vArmor/releases/tag/v0.10.4).

--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -22,13 +22,13 @@ vArmor can be deployed via a Helm chart which is the recommended and preferred m
 In order to install vArmor with Helm, first fetch the chart.
 
 ```
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 Then install it with helm optional [configurations](#configuration).
 
 ```
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com"
 ```
@@ -210,7 +210,7 @@ The NetworkProxy enforcer transparently redirects traffic by injecting iptables 
 You can use helm commands to upgrade, rollback, and perform other operations.
 
 ```bash
-helm upgrade varmor varmor-0.10.3.tgz \
+helm upgrade varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com" \
     --set bpfLsmEnforcer.enabled=true \

--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -156,6 +156,55 @@ You can use the following option to change this behavior. Default: disabled.
 ```
 
 
+### Dynamic Configuration
+
+Besides the install-time Helm options above, vArmor ships a runtime-reloadable configuration carried by the `varmor-config` ConfigMap in vArmor's namespace. The manager watches this ConfigMap via an informer and hot-reloads changes **without a restart**. If the ConfigMap is absent or malformed, the manager falls back to the built-in defaults (which are identical to the values shipped by the chart). You can seed its initial content through the `dynamicConfig` value at install time, or edit the ConfigMap directly afterwards.
+
+```bash
+kubectl -n varmor edit configmap varmor-config
+```
+
+#### Default Resources of the NetworkProxy Sidecar
+You can set the cluster-wide default resource requests/limits for the injected NetworkProxy (Envoy) sidecar, so an administrator can tune sidecar resources once instead of setting `.spec.policy.networkProxy.resources` on every policy.
+
+The injector resolves the final resources with a three-layer, field-level merge chain, where each leaf value (`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`) falls back independently:
+
+> per-policy override (`.spec.policy.networkProxy.resources`) > this cluster-global config > built-in defaults
+
+Two independent, MITM-aware tiers are provided, because a MITM sidecar runs heavier (double TLS handshakes). A MITM sidecar reads **only** the `mitm` tier and a non-MITM sidecar reads **only** the `nonMitm` tier — the tiers are **not** inherited from each other. The built-in defaults are:
+
+| Tier | CPU requests | Memory requests | CPU limits | Memory limits |
+|------|-------------|----------------|-----------|--------------|
+| `nonMitm` | 50m | 64Mi | 500m | 256Mi |
+| `mitm` | 100m | 128Mi | 1000m | 512Mi |
+
+```bash
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.cpu="50m" \
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.memory="64Mi" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.cpu="1000m" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.memory="512Mi"
+```
+
+Notes:
+* Always quote quantities as strings (e.g. `"500m"`, `"256Mi"`). An unquoted bare number is parsed as an integer, so `memory: 100` means **100 bytes**, not 100Mi.
+* The tier keys must be spelled exactly `nonMitm` and `mitm`. A misspelled tier key is silently ignored and that tier falls back to the built-in defaults.
+* Invalid entries (an unknown resource name, an unparseable quantity, a non-positive value, or a limit set below its request in the same tier) are ignored and logged by the manager at load time; that field falls back to its built-in default.
+
+#### Micro-VM (Kata) Detection for NetworkProxy Auditing
+The NetworkProxy enforcer persists egress violation audit logs through its Envoy sidecar. Under a runc runtime, Envoy streams the records over a node-level hostPath Unix socket to the `varmor-agent` DaemonSet. Under a micro-VM runtime (kata / serverless sandbox) the sidecar runs inside a micro-VM, so that hostPath socket cannot cross the VM boundary (and is rejected at admission by some serverless providers). For such workloads vArmor omits the hostPath volume/mount and starts an in-sidecar audit sink that binds the socket in the container's own rootfs and writes the container-local `/var/log/varmor/violations.log` — producing byte-identical normalized records to the runc path.
+
+The `microVMDetection` config tells the injector which workloads run under a micro-VM runtime. A workload matches if its `runtimeClassName` is listed **OR** any annotation rule matches **OR** any label rule matches (for annotation/label rules, an empty value matches on key presence alone; a non-empty value must match exactly). The built-in defaults already cover upstream kata and the major cloud serverless runtimes:
+
+* `runtimeClassNames`: `kata`, `kata-qemu`, `kata-clh`
+* annotation: `vke.volcengine.com/burst-to-vci=enforce` (Volcengine VKE burst-to-VCI)
+* label: `alibabacloud.com/eci=true` (Alibaba Cloud ECI)
+
+To extend the rules for a custom micro-VM runtime, edit the `varmor-config` ConfigMap or set the `dynamicConfig.microVMDetection` values at install time.
+
+#### iptables Backend for NetworkProxy Traffic Redirection
+The NetworkProxy enforcer transparently redirects traffic by injecting iptables rules through an init container. Starting from the `proxyinit:v0.2` image, vArmor automatically detects the iptables backend (`legacy` vs `nft`) already in use in the target network namespace and drives the matching backend, instead of hardcoding one. This prevents traffic from being silently blackholed in shared-netns setups — for example a kata Pod whose netns is also programmed by a PaaS mesh init using the `legacy` backend. On a fresh netns it defaults to `nft` (matching prior behaviour); if both backends already carry rules it aborts with a `CONFLICT` rather than guessing. This is fully automatic and requires no configuration; just make sure the chart pulls `proxyinit:v0.2` or later.
+
+
 ## Upgrade
 
 You can use helm commands to upgrade, rollback, and perform other operations.

--- a/website/docs/getting_started/interface_specification.md
+++ b/website/docs/getting_started/interface_specification.md
@@ -257,6 +257,8 @@ Built-in defaults:
 | Non-MITM | 50m | 64Mi | 500m | 256Mi |
 | MITM | 100m | 128Mi | 1000m | 512Mi |
 
+> The resolved resources follow a three-layer, field-level merge chain: this per-policy override > the cluster-global default set in the `varmor-config` ConfigMap > the built-in defaults above. See [Default Resources of the NetworkProxy Sidecar](./installation.md#default-resources-of-the-networkproxy-sidecar) for the cluster-global configuration.
+
 ## NetworkProxyRules
 
 | Field | Description |

--- a/website/docs/getting_started/usage_instructions.md
+++ b/website/docs/getting_started/usage_instructions.md
@@ -41,6 +41,7 @@ Notes:
 * Limited by the principle and performance impact of Seccomp, you can only use `auditViolations=true` and `allowViolations=true` in combination to implement the audit-only mode (observation mode) for the Seccomp enforcer when there is no policy in the BehaviorModeling mode.
 * Limited by the principle of the AppArmor LSM and Seccomp, when using the AppArmor or Seccomp enforcer, it may not be possible to associate container and Pod information for the short-lived processes.
 * The NetworkProxy enforcer reports egress traffic audit events through its Envoy sidecar. Because these events are produced by the proxy at the Pod granularity, they only carry Pod-level identity (`nodeName`, `podName`, `podNamespace`, `podUID`).
+* For the NetworkProxy enforcer, the way violation records reach `/var/log/varmor/violations.log` depends on the runtime. Under runc, the Envoy sidecar streams them to the node-level `varmor-agent`, which writes the log on the host. Under a micro-VM runtime (kata / serverless sandbox), an in-sidecar audit sink writes the log inside the container's own filesystem instead (the records are byte-identical). Whether a workload is treated as micro-VM is decided by the `microVMDetection` rules in the `varmor-config` ConfigMap; see [Micro-VM (Kata) Detection for NetworkProxy Auditing](../getting_started/installation.md#micro-vm-kata-detection-for-networkproxy-auditing).
 
 ```json
 {

--- a/website/docs/getting_started/usage_instructions.md
+++ b/website/docs/getting_started/usage_instructions.md
@@ -61,6 +61,9 @@ Notes:
   "enforcer": "BPF",
   "action": "DENIED",
   "profileName": "varmor-demo-demo-2",
+  "policyKind": "VarmorPolicy",
+  "policyName": "demo-2",
+  "policyNamespace": "demo",
   "event": {
     "operation": "File",
     "permissions": [

--- a/website/docs/guides/policy_tools/policy_advisor.md
+++ b/website/docs/guides/policy_tools/policy_advisor.md
@@ -19,6 +19,8 @@ Filter out the conflicted built-in rules with behavior data to make the policy t
 
 `policy-advisor.py AppArmor,BPF -f share-containers-pid-ns -c sys_admin,net_admin,kill -m data.json`
 
+> When matching behavior data against rules such as `disable-shell`, the advisor keys off both the executable basename and its file-extension token. So a shell recorded only as a script path (e.g. `/var/lib/cilium/bpf/init.sh`, with no `sh`/`bash`/`dash` binary) is still detected as a conflict via its `.sh` extension, and the conflicting rule is filtered out.
+
 
 ## Usage
 ```

--- a/website/docs/introduction.mdx
+++ b/website/docs/introduction.mdx
@@ -93,14 +93,14 @@ The prerequisites required by different enforcers are as shown in the following 
 ## Quick Start
 ### Step 1. Fetch chart
 ```
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 ### Step 2. Install
 The default configuration enables the AppArmor and Seccomp enforcers. Please refer to the documentation for more [configuration options](getting_started/installation#configuration).
 
 ```
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com"
 ```

--- a/website/i18n/zh-cn/docusaurus-plugin-content-blog/2026-08-04-0.10.4-overview/index.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-blog/2026-08-04-0.10.4-overview/index.md
@@ -1,0 +1,112 @@
+---
+slug: varmor-0.10.4-new-features-overview
+title: "vArmor v0.10.4: NetworkProxy 审计落地、微虚机(Kata)兼容与生产化运维增强"
+authors: [DannyWei]
+tags: [NewFeatures, ReleaseNotes, AIAgent, NetworkProxy]
+date: 2026-08-04T00:00
+---
+
+在 vArmor v0.10.0 中，我们引入了 [NetworkProxy enforcer](/zh-cn/blog/varmor-0.10.0-new-features-overview/)，以 Sidecar 代理架构为 Kubernetes 工作负载带来了 L4/L7 网络访问控制能力；在 [v0.10.1](/zh-cn/blog/varmor-0.10.1-new-features-overview/) 中，我们完成了第二阶段的 TLS 中间人（MITM）能力，将其升级为覆盖加密流量的深度包检测引擎。
+
+vArmor v0.10.4 是一次面向 **生产化** 的发版。我们把重心放在：让 NetworkProxy 的 **审计能力真正落地**——审计日志可持久化、可关联工作负载身份；让 vArmor 在 **微虚机（Kata / Serverless 沙箱）** 等非标准运行时环境中稳定工作；并通过 **集群级 Sidecar 资源配额管理** 和 **iptables 后端自适应** 降低大规模部署的运维成本。此外，policy-advisor 的冲突检测也更加精准。
+
+<!--truncate-->
+
+## 为什么聚焦"审计落地"与"运行时兼容"？
+
+NetworkProxy enforcer 在前两个版本解决了"能不能管控"的问题——从域名级守门到加密流量的深度检测。但当用户把它部署到真实的生产集群，尤其是运行 AI Agent 的多租户环境时，新的工程问题浮现出来：
+
+- **审计日志去哪了？** enforcer 支持 `audit` 限定符，但被审计的出口流量记录需要一个稳定、可采集的落盘位置，并且要能关联到具体是哪个 Pod、哪个工作负载产生的。
+- **微虚机场景怎么办？** 越来越多的 AI Agent 工作负载运行在 Kata Containers 或云厂商 Serverless（如火山引擎 VCI、阿里云 ECI）之上。这类微虚机运行时的网络命名空间和挂载边界与 runc 不同，原有的审计采集路径和 iptables 注入方式会失效甚至导致流量被静默丢弃。
+- **大规模部署的资源怎么统一管？** MITM Sidecar 比直通代理更消耗资源，逐条策略配置资源配额在集群规模上并不现实。
+
+v0.10.4 正是围绕这三个问题展开。
+
+## NetworkProxy 出口审计日志持久化
+
+NetworkProxy enforcer 通过其 Envoy Sidecar 上报出口流量的违规审计事件。v0.10.4 完成了这条审计链路的持久化落地：
+
+- **统一落盘路径**：所有被审计的出口流量记录最终写入容器可见的 `/var/log/varmor/violations.log`，格式为归一化的结构化记录，便于日志采集系统统一消费。
+- **节点级采集（runc）**：在 runc 运行时下，Envoy Sidecar 通过节点级的 hostPath Unix Domain Socket，将审计记录以 gRPC ALS（Access Log Service）方式流式发送到节点上的 `varmor-agent` DaemonSet，由 agent 负责写入日志文件。这样审计数据的写入与采集解耦，不占用应用容器的资源与权限。
+- **Pod 级身份关联**：由于这些事件由代理在 Pod 粒度上产生，每条记录都携带 Pod 级别的身份信息（`nodeName`、`podName`、`podNamespace`、`podUID`），安全团队可以据此把每一次网络访问精确关联到具体工作负载，而不再是一条脱离上下文的孤立日志。
+
+这使得 NetworkProxy 的审计模式从"能记录"进化为"能被生产级日志体系采集、能被关联溯源"。
+
+## 微虚机（Kata / Serverless）审计与流量重定向兼容
+
+这是 v0.10.4 面向真实 AI Agent 部署环境的核心改进。微虚机运行时（Kata、Serverless 沙箱）的边界与 runc 截然不同，vArmor 在两条关键路径上做了自适应处理。
+
+### 审计采集：Sidecar 内置 ALS Sink
+
+在微虚机运行时下，Sidecar 运行在微虚机内部，前述的节点级 hostPath Socket **无法跨越虚机边界**（部分 Serverless 厂商甚至会在准入阶段直接拒绝这类 hostPath 挂载）。为此，vArmor 对被识别为微虚机的工作负载：
+
+- **省略 hostPath 卷与挂载**，避免因挂载被拒导致 Pod 无法调度；
+- **启动一个 Sidecar 内置的审计 Sink**，将 Socket 绑定在容器自身的 rootfs 中，直接写入容器本地的 `/var/log/varmor/violations.log`。
+
+无论 runc 还是微虚机，最终产出的审计记录 **逐字节一致**，上层采集与分析逻辑无需区分运行时。
+
+### 微虚机识别：`microVMDetection`
+
+vArmor 通过 `microVMDetection` 配置来判断哪些工作负载运行在微虚机运行时下。判定逻辑为：工作负载的 `runtimeClassName` 命中列表 **或** 任一 annotation 规则命中 **或** 任一 label 规则命中（对 annotation/label 规则，空值表示仅按键是否存在匹配，非空值则必须精确匹配）。内置默认值已覆盖上游 Kata 及主流云厂商的 Serverless 运行时：
+
+| 维度 | 内置默认值 |
+|------|-----------|
+| `runtimeClassNames` | `kata`、`kata-qemu`、`kata-clh` |
+| annotation | `vke.volcengine.com/burst-to-vci=enforce`（火山引擎 VKE burst-to-VCI） |
+| label | `alibabacloud.com/eci=true`（阿里云 ECI） |
+
+如需为自定义的微虚机运行时扩展识别规则，可编辑 `varmor-config` ConfigMap，或在安装时设置 `dynamicConfig.microVMDetection` 的取值，**无需重启即可热加载**。
+
+### 流量重定向：iptables 后端自适应
+
+NetworkProxy enforcer 通过 init 容器注入 iptables 规则来透明地重定向出口流量。不同运行时和不同基础设施（如某些 PaaS mesh）使用的 iptables 后端并不一致（`legacy` 与 `nft`），硬编码某一种后端可能导致流量被静默丢弃——例如一个 Kata Pod 的网络命名空间同时被使用 `legacy` 后端的 PaaS mesh init 编程时。
+
+从 `proxyinit:v0.2` 镜像开始，vArmor **自动探测目标网络命名空间中已在使用的 iptables 后端并驱动匹配的后端**：
+
+- 在全新的网络命名空间上默认使用 `nft`（与既有行为保持一致）；
+- 若检测到两种后端都已存在规则，则以 `CONFLICT` 显式中止，而非盲目猜测导致隐蔽故障。
+
+该能力完全自动、无需任何配置开关，只需确保 Chart 拉取 `proxyinit:v0.2` 或更新版本即可。
+
+## 集群级 Sidecar 资源配额管理
+
+在 [v0.10.1 的未来规划](/zh-cn/blog/varmor-0.10.1-new-features-overview/)中，我们提出要提供集群级的 Sidecar 资源默认值管理。v0.10.4 兑现了这一承诺。
+
+vArmor 新增了一份运行时可热加载的动态配置，承载于 vArmor 所在命名空间下的 `varmor-config` ConfigMap 中。Manager 通过 informer 监听该 ConfigMap，变更时 **无需重启** 即可热加载；若 ConfigMap 缺失或格式非法，则回退到与 Chart 随附取值完全一致的内置默认值。
+
+管理员从此只需 **配置一次**，即可为整个集群注入的 NetworkProxy Sidecar 设置默认资源 requests/limits，而不必在每条策略上单独设置 `.spec.policy.networkProxy.resources`。注入器采用 **三层、字段级的合并链** 解析最终资源，每个叶子字段（`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`）独立回退：
+
+> 策略级覆盖 > 集群级全局配置（`varmor-config`） > 内置默认值
+
+考虑到 MITM Sidecar 负载更重（双向 TLS 握手），配置区分为两个相互独立的层级——MITM Sidecar 只读取 `mitm` 层，非 MITM Sidecar 只读取 `nonMitm` 层，两层之间不相互继承。内置默认值如下：
+
+| 层级 | CPU requests | 内存 requests | CPU limits | 内存 limits |
+|------|-------------|---------------|-----------|-------------|
+| `nonMitm` | 50m | 64Mi | 500m | 256Mi |
+| `mitm` | 100m | 128Mi | 1000m | 512Mi |
+
+```bash
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.cpu="50m" \
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.memory="64Mi" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.cpu="1000m" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.memory="512Mi"
+```
+
+使用时需注意：资源数量务必以字符串形式加引号（如 `"500m"`、`"256Mi"`），未加引号的裸数字会被解析为整数（`memory: 100` 表示 100 字节而非 100Mi）；层级键名必须严格拼写为 `nonMitm` 和 `mitm`，拼写错误会被静默忽略并回退到内置默认值；非法条目（未知资源名、无法解析的数量、非正值，或同层内 limit 低于 request）会被忽略并在 Manager 加载时记录日志。
+
+## policy-advisor：更精准的 shell 使用冲突检测
+
+policy-advisor 支持基于行为数据过滤掉与之冲突的内置规则，使生成的策略模板更加精准。v0.10.4 增强了 `disable-shell` 等规则的匹配能力：advisor 在匹配时会 **同时依据可执行文件的 basename 及其文件扩展名** 进行判断。
+
+因此，即使某个 shell 仅以脚本路径的形式出现在行为数据中（例如 `/var/lib/cilium/bpf/init.sh`，而没有独立的 `sh`/`bash`/`dash` 二进制执行记录），也能通过其 `.sh` 扩展名被正确识别为冲突，从而过滤掉相应的冲突规则，避免生成误伤业务的策略。
+
+## 升级说明
+
+- NetworkProxy 的 init 容器镜像需为 `proxyinit:v0.2` 或更新版本，以启用 iptables 后端自适应能力。
+- 微虚机识别与 Sidecar 资源默认值均通过 `varmor-config` ConfigMap 的 `dynamicConfig` 承载，支持安装时初始化，也支持安装后热更新，变更无需重启。
+
+## 总结
+
+如果说 v0.10.0 和 v0.10.1 回答了"vArmor 能否管控 AI Agent 的网络行为"，那么 v0.10.4 回答的是"vArmor 能否在真实的生产集群里稳定、可观测、低运维成本地做到这一点"。通过审计日志的持久化与 Pod 级身份关联、对微虚机（Kata / Serverless）运行时在审计采集与流量重定向两条路径上的自适应兼容、集群级 Sidecar 资源配额的统一管理，以及 policy-advisor 更精准的冲突检测，本次发版让 NetworkProxy enforcer 更加贴近大规模、多运行时、多租户的真实部署环境。
+
+欢迎升级体验 vArmor v0.10.4，并通过 [GitHub](https://github.com/bytedance/vArmor) 向我们反馈使用体验！完整详情请参阅 [Release Notes](https://github.com/bytedance/vArmor/releases/tag/v0.10.4)。

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/installation.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/installation.md
@@ -153,6 +153,55 @@ vArmor 的 Agent 默认运行在独立的网络命名空间中，并在端口 `9
 --set removeAllSeccompProfiles.enabled=true
 ```
 
+### 动态配置
+
+除了上述安装时的 Helm 选项外，vArmor 还提供一份运行时可热加载的配置，承载于 vArmor 所在命名空间下的 `varmor-config` ConfigMap 中。Manager 通过 informer 监听该 ConfigMap，并在变更时**无需重启**即可热加载。如果该 ConfigMap 缺失或格式非法，Manager 会回退到内置默认值（与 Chart 随附的取值完全一致）。你可以在安装时通过 `dynamicConfig` value 设置其初始内容，也可以在安装后直接编辑该 ConfigMap。
+
+```bash
+kubectl -n varmor edit configmap varmor-config
+```
+
+#### NetworkProxy Sidecar 的默认资源
+你可以为注入的 NetworkProxy(Envoy) sidecar 设置集群级的默认资源 requests/limits，这样管理员只需配置一次，而不必在每个策略上单独设置 `.spec.policy.networkProxy.resources`。
+
+注入器采用三层、字段级的合并链来解析最终资源，其中每个叶子字段(`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`)独立回退：
+
+> 策略级覆盖(`.spec.policy.networkProxy.resources`) > 本集群级全局配置 > 内置默认值
+
+由于 MITM sidecar 负载更重(双向 TLS 握手)，配置分为两个相互独立且区分 MITM 的层级。MITM sidecar **只**读取 `mitm` 层，非 MITM sidecar **只**读取 `nonMitm` 层——两层之间**不会**相互继承。内置默认值如下：
+
+| 层级 | CPU requests | 内存 requests | CPU limits | 内存 limits |
+|------|-------------|----------------|-----------|--------------|
+| `nonMitm` | 50m | 64Mi | 500m | 256Mi |
+| `mitm` | 100m | 128Mi | 1000m | 512Mi |
+
+```bash
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.cpu="50m" \
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.memory="64Mi" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.cpu="1000m" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.memory="512Mi"
+```
+
+注意事项：
+* 资源数量务必以字符串形式加引号(如 `"500m"`、`"256Mi"`)。未加引号的裸数字会被解析为整数，因此 `memory: 100` 表示 **100 字节**，而非 100Mi。
+* 层级键名必须严格拼写为 `nonMitm` 和 `mitm`。拼写错误的层级键会被静默忽略，该层级将回退到内置默认值。
+* 非法条目(未知资源名、无法解析的数量、非正值，或同一层级内 limit 低于 request)会被忽略，并在 Manager 加载时记录日志；该字段将回退到其内置默认值。
+
+#### NetworkProxy 审计的微虚机(Kata)识别
+NetworkProxy enforcer 通过其 Envoy sidecar 持久化出口流量的违规审计日志。在 runc 运行时下，Envoy 通过节点级的 hostPath Unix socket 将记录流式发送到 `varmor-agent` DaemonSet。而在微虚机运行时(kata / Serverless 沙箱)下，sidecar 运行在微虚机内部，该 hostPath socket 无法跨越虚机边界(且部分 Serverless 厂商会在准入阶段拒绝挂载)。对于此类工作负载，vArmor 会省略 hostPath 卷/挂载，并启动一个 sidecar 内置的审计 sink，将 socket 绑定在容器自身 rootfs 中，写入容器本地的 `/var/log/varmor/violations.log`——产出与 runc 路径逐字节一致的归一化记录。
+
+`microVMDetection` 配置用于告知注入器哪些工作负载运行在微虚机运行时下。当工作负载的 `runtimeClassName` 命中列表**或**任一 annotation 规则命中**或**任一 label 规则命中时，即判定为微虚机(对于 annotation/label 规则，空值表示仅按键是否存在匹配，非空值则必须精确匹配)。内置默认值已覆盖上游 kata 及主流云厂商的 Serverless 运行时：
+
+* `runtimeClassNames`：`kata`、`kata-qemu`、`kata-clh`
+* annotation：`vke.volcengine.com/burst-to-vci=enforce`(火山引擎 VKE burst-to-VCI)
+* label：`alibabacloud.com/eci=true`(阿里云 ECI)
+
+如需为自定义的微虚机运行时扩展识别规则，可编辑 `varmor-config` ConfigMap，或在安装时设置 `dynamicConfig.microVMDetection` 的取值。
+
+#### NetworkProxy 流量重定向的 iptables 后端
+NetworkProxy enforcer 通过 init 容器注入 iptables 规则来透明地重定向流量。从 `proxyinit:v0.2` 镜像开始，vArmor 会自动探测目标网络命名空间中已在使用的 iptables 后端(`legacy` 与 `nft`)并驱动匹配的后端，而不再硬编码某一种。这可以避免在共享 netns 的场景下流量被静默丢弃——例如某个 kata Pod 的 netns 同时被使用 `legacy` 后端的 PaaS mesh init 编程。在全新的 netns 上默认使用 `nft`(与既有行为一致);若两种后端都已存在规则，则会以 `CONFLICT` 中止而非盲目猜测。该能力完全自动、无需配置，只需确保 Chart 拉取 `proxyinit:v0.2` 或更新版本即可。
+
+
 ## 更新
 
 你可以使用 helm 命令进行升级、回滚等操作。

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/installation.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/installation.md
@@ -20,13 +20,13 @@ description: 了解如何安装、配置、更新和卸载 vArmor。
 vArmor 推荐使用 Helm chart 进行部署。通过 Helm 安装前，请先拉取 chart 包。
 
 ```
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 然后使用 helm 命令及[配置选项](#配置选项)进行安装和配置。
 
 ```
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-cn-beijing.cr.volces.com"
 ```
@@ -207,7 +207,7 @@ NetworkProxy enforcer 通过 init 容器注入 iptables 规则来透明地重定
 你可以使用 helm 命令进行升级、回滚等操作。
 
 ```bash
-helm upgrade varmor varmor-0.10.3.tgz \
+helm upgrade varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com" \
     --set bpfLsmEnforcer.enabled=true \

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/interface_specification.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/interface_specification.md
@@ -257,6 +257,8 @@ description: vArmor 的接口规范。
 | 非 MITM | 50m | 64Mi | 500m | 256Mi |
 | MITM | 100m | 128Mi | 1000m | 512Mi |
 
+> 最终资源遵循三层、字段级的合并链：本策略级覆盖 > `varmor-config` ConfigMap 中设置的集群级默认值 > 上述内置默认值。集群级配置详见[NetworkProxy Sidecar 的默认资源](./installation.md#networkproxy-sidecar-的默认资源)。
+
 ## NetworkProxyRules
 
 | 字段 | 描述 |

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/usage_instructions.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/usage_instructions.md
@@ -43,6 +43,7 @@ vArmor 支持将策略对象配置为仅审计不拦截（观察模式）、拦�
 * 受限于 Seccomp 原理和性能影响，您需要组合使用 `auditViolations=true` 和 `allowViolations=true`，在没有策略处于 BehaviorModeling 模式时，实现仅审计不拦截的效果（观察模式）。
 * 受限于 AppArmor LSM 和 Seccomp 的原理，使用 AppArmor 或 Seccomp enforcer 时，可能无法关联短进程的所属容器和 Pod 信息。
 * NetworkProxy enforcer 通过其 Envoy sidecar 上报出口流量的审计事件。由于这些事件由代理在 Pod 粒度上产生，因此仅携带 Pod 级别的身份信息（`nodeName`、`podName`、`podNamespace`、`podUID`）。
+* 对于 NetworkProxy enforcer，违规记录写入 `/var/log/varmor/violations.log` 的方式取决于运行时。在 runc 下，Envoy sidecar 将记录流式发送到节点级的 `varmor-agent`，由其写入宿主机上的日志文件；在微虚机运行时(kata / Serverless 沙箱)下，则改由 sidecar 内置的审计 sink 写入容器自身文件系统中的日志文件(记录内容逐字节一致)。工作负载是否被视为微虚机，由 `varmor-config` ConfigMap 中的 `microVMDetection` 规则决定，详见[NetworkProxy 审计的微虚机(Kata)识别](../getting_started/installation.md#networkproxy-审计的微虚机kata识别)。
 
 ```json
 {

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/usage_instructions.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/usage_instructions.md
@@ -63,6 +63,9 @@ vArmor 支持将策略对象配置为仅审计不拦截（观察模式）、拦�
   "enforcer": "BPF",
   "action": "DENIED",
   "profileName": "varmor-demo-demo-2",
+  "policyKind": "VarmorPolicy",
+  "policyName": "demo-2",
+  "policyNamespace": "demo",
   "event": {
     "operation": "File",
     "permissions": [

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/policy_tools/policy_advisor.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/guides/policy_tools/policy_advisor.md
@@ -25,6 +25,8 @@ description: 使用策略顾问生成策略模版。
 
 `policy-advisor.py AppArmor,BPF -f share-containers-pid-ns -c sys_admin,net_admin,kill -m data.json`
 
+> 在将行为数据与 `disable-shell` 等规则进行匹配时，advisor 会同时依据可执行文件的 basename 及其文件扩展名进行判断。因此，即使某个 shell 仅以脚本路径的形式被记录(例如 `/var/lib/cilium/bpf/init.sh`，且没有 `sh`/`bash`/`dash` 二进制),也能通过其 `.sh` 扩展名被识别为冲突，从而过滤掉相应的冲突规则。
+
 
 ## 用法
 

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/introduction.mdx
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/introduction.mdx
@@ -97,14 +97,14 @@ vArmor 的策略可以运行在五种模式中：*AlwaysAllow, RuntimeDefault, E
 ### 步骤 1. 拉取 chart 包
 
 ```bash
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 ### 步骤 2. 安装
 vArmor 默认支持 AppArmor 和 Seccomp enforcer。请参照 [配置选项](getting_started/installation#配置选项) 查看更多信息。
 
 ```bash
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-cn-beijing.cr.volces.com"
 ```

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/installation.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/installation.md
@@ -153,6 +153,55 @@ vArmor 的 Agent 默认运行在独立的网络命名空间中，并在端口 `9
 --set removeAllSeccompProfiles.enabled=true
 ```
 
+### 动态配置
+
+除了上述安装时的 Helm 选项外，vArmor 还提供一份运行时可热加载的配置，承载于 vArmor 所在命名空间下的 `varmor-config` ConfigMap 中。Manager 通过 informer 监听该 ConfigMap，并在变更时**无需重启**即可热加载。如果该 ConfigMap 缺失或格式非法，Manager 会回退到内置默认值（与 Chart 随附的取值完全一致）。你可以在安装时通过 `dynamicConfig` value 设置其初始内容，也可以在安装后直接编辑该 ConfigMap。
+
+```bash
+kubectl -n varmor edit configmap varmor-config
+```
+
+#### NetworkProxy Sidecar 的默认资源
+你可以为注入的 NetworkProxy(Envoy) sidecar 设置集群级的默认资源 requests/limits，这样管理员只需配置一次，而不必在每个策略上单独设置 `.spec.policy.networkProxy.resources`。
+
+注入器采用三层、字段级的合并链来解析最终资源，其中每个叶子字段(`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`)独立回退：
+
+> 策略级覆盖(`.spec.policy.networkProxy.resources`) > 本集群级全局配置 > 内置默认值
+
+由于 MITM sidecar 负载更重(双向 TLS 握手)，配置分为两个相互独立且区分 MITM 的层级。MITM sidecar **只**读取 `mitm` 层，非 MITM sidecar **只**读取 `nonMitm` 层——两层之间**不会**相互继承。内置默认值如下：
+
+| 层级 | CPU requests | 内存 requests | CPU limits | 内存 limits |
+|------|-------------|----------------|-----------|--------------|
+| `nonMitm` | 50m | 64Mi | 500m | 256Mi |
+| `mitm` | 100m | 128Mi | 1000m | 512Mi |
+
+```bash
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.cpu="50m" \
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.memory="64Mi" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.cpu="1000m" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.memory="512Mi"
+```
+
+注意事项：
+* 资源数量务必以字符串形式加引号(如 `"500m"`、`"256Mi"`)。未加引号的裸数字会被解析为整数，因此 `memory: 100` 表示 **100 字节**，而非 100Mi。
+* 层级键名必须严格拼写为 `nonMitm` 和 `mitm`。拼写错误的层级键会被静默忽略，该层级将回退到内置默认值。
+* 非法条目(未知资源名、无法解析的数量、非正值，或同一层级内 limit 低于 request)会被忽略，并在 Manager 加载时记录日志；该字段将回退到其内置默认值。
+
+#### NetworkProxy 审计的微虚机(Kata)识别
+NetworkProxy enforcer 通过其 Envoy sidecar 持久化出口流量的违规审计日志。在 runc 运行时下，Envoy 通过节点级的 hostPath Unix socket 将记录流式发送到 `varmor-agent` DaemonSet。而在微虚机运行时(kata / Serverless 沙箱)下，sidecar 运行在微虚机内部，该 hostPath socket 无法跨越虚机边界(且部分 Serverless 厂商会在准入阶段拒绝挂载)。对于此类工作负载，vArmor 会省略 hostPath 卷/挂载，并启动一个 sidecar 内置的审计 sink，将 socket 绑定在容器自身 rootfs 中，写入容器本地的 `/var/log/varmor/violations.log`——产出与 runc 路径逐字节一致的归一化记录。
+
+`microVMDetection` 配置用于告知注入器哪些工作负载运行在微虚机运行时下。当工作负载的 `runtimeClassName` 命中列表**或**任一 annotation 规则命中**或**任一 label 规则命中时，即判定为微虚机(对于 annotation/label 规则，空值表示仅按键是否存在匹配，非空值则必须精确匹配)。内置默认值已覆盖上游 kata 及主流云厂商的 Serverless 运行时：
+
+* `runtimeClassNames`：`kata`、`kata-qemu`、`kata-clh`
+* annotation：`vke.volcengine.com/burst-to-vci=enforce`(火山引擎 VKE burst-to-VCI)
+* label：`alibabacloud.com/eci=true`(阿里云 ECI)
+
+如需为自定义的微虚机运行时扩展识别规则，可编辑 `varmor-config` ConfigMap，或在安装时设置 `dynamicConfig.microVMDetection` 的取值。
+
+#### NetworkProxy 流量重定向的 iptables 后端
+NetworkProxy enforcer 通过 init 容器注入 iptables 规则来透明地重定向流量。从 `proxyinit:v0.2` 镜像开始，vArmor 会自动探测目标网络命名空间中已在使用的 iptables 后端(`legacy` 与 `nft`)并驱动匹配的后端，而不再硬编码某一种。这可以避免在共享 netns 的场景下流量被静默丢弃——例如某个 kata Pod 的 netns 同时被使用 `legacy` 后端的 PaaS mesh init 编程。在全新的 netns 上默认使用 `nft`(与既有行为一致);若两种后端都已存在规则，则会以 `CONFLICT` 中止而非盲目猜测。该能力完全自动、无需配置，只需确保 Chart 拉取 `proxyinit:v0.2` 或更新版本即可。
+
+
 ## 更新
 
 你可以使用 helm 命令进行升级、回滚等操作。

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/installation.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/installation.md
@@ -20,13 +20,13 @@ description: 了解如何安装、配置、更新和卸载 vArmor。
 vArmor 推荐使用 Helm chart 进行部署。通过 Helm 安装前，请先拉取 chart 包。
 
 ```
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 然后使用 helm 命令及[配置选项](#配置选项)进行安装和配置。
 
 ```
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-cn-beijing.cr.volces.com"
 ```
@@ -207,7 +207,7 @@ NetworkProxy enforcer 通过 init 容器注入 iptables 规则来透明地重定
 你可以使用 helm 命令进行升级、回滚等操作。
 
 ```bash
-helm upgrade varmor varmor-0.10.3.tgz \
+helm upgrade varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com" \
     --set bpfLsmEnforcer.enabled=true \

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/interface_specification.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/interface_specification.md
@@ -257,6 +257,8 @@ description: vArmor 的接口规范。
 | 非 MITM | 50m | 64Mi | 500m | 256Mi |
 | MITM | 100m | 128Mi | 1000m | 512Mi |
 
+> 最终资源遵循三层、字段级的合并链：本策略级覆盖 > `varmor-config` ConfigMap 中设置的集群级默认值 > 上述内置默认值。集群级配置详见[NetworkProxy Sidecar 的默认资源](./installation.md#networkproxy-sidecar-的默认资源)。
+
 ## NetworkProxyRules
 
 | 字段 | 描述 |

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/usage_instructions.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/usage_instructions.md
@@ -43,6 +43,7 @@ vArmor 支持将策略对象配置为仅审计不拦截（观察模式）、拦�
 * 受限于 Seccomp 原理和性能影响，您需要组合使用 `auditViolations=true` 和 `allowViolations=true`，在没有策略处于 BehaviorModeling 模式时，实现仅审计不拦截的效果（观察模式）。
 * 受限于 AppArmor LSM 和 Seccomp 的原理，使用 AppArmor 或 Seccomp enforcer 时，可能无法关联短进程的所属容器和 Pod 信息。
 * NetworkProxy enforcer 通过其 Envoy sidecar 上报出口流量的审计事件。由于这些事件由代理在 Pod 粒度上产生，因此仅携带 Pod 级别的身份信息（`nodeName`、`podName`、`podNamespace`、`podUID`）。
+* 对于 NetworkProxy enforcer，违规记录写入 `/var/log/varmor/violations.log` 的方式取决于运行时。在 runc 下，Envoy sidecar 将记录流式发送到节点级的 `varmor-agent`，由其写入宿主机上的日志文件；在微虚机运行时(kata / Serverless 沙箱)下，则改由 sidecar 内置的审计 sink 写入容器自身文件系统中的日志文件(记录内容逐字节一致)。工作负载是否被视为微虚机，由 `varmor-config` ConfigMap 中的 `microVMDetection` 规则决定，详见[NetworkProxy 审计的微虚机(Kata)识别](../getting_started/installation.md#networkproxy-审计的微虚机kata识别)。
 
 ```json
 {
@@ -62,6 +63,9 @@ vArmor 支持将策略对象配置为仅审计不拦截（观察模式）、拦�
   "enforcer": "BPF",
   "action": "DENIED",
   "profileName": "varmor-demo-demo-2",
+  "policyKind": "VarmorPolicy",
+  "policyName": "demo-2",
+  "policyNamespace": "demo",
   "event": {
     "operation": "File",
     "permissions": [

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/guides/policy_tools/policy_advisor.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/guides/policy_tools/policy_advisor.md
@@ -25,6 +25,8 @@ description: 使用策略顾问生成策略模版。
 
 `policy-advisor.py AppArmor,BPF -f share-containers-pid-ns -c sys_admin,net_admin,kill -m data.json`
 
+> 在将行为数据与 `disable-shell` 等规则进行匹配时，advisor 会同时依据可执行文件的 basename 及其文件扩展名进行判断。因此，即使某个 shell 仅以脚本路径的形式被记录(例如 `/var/lib/cilium/bpf/init.sh`，且没有 `sh`/`bash`/`dash` 二进制),也能通过其 `.sh` 扩展名被识别为冲突，从而过滤掉相应的冲突规则。
+
 
 ## 用法
 

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/introduction.mdx
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/introduction.mdx
@@ -97,14 +97,14 @@ vArmor 的策略可以运行在五种模式中：*AlwaysAllow, RuntimeDefault, E
 ### 步骤 1. 拉取 chart 包
 
 ```bash
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 ### 步骤 2. 安装
 vArmor 默认支持 AppArmor 和 Seccomp enforcer。请参照 [配置选项](getting_started/installation#配置选项) 查看更多信息。
 
 ```bash
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-cn-beijing.cr.volces.com"
 ```

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13888,9 +13888,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -170,13 +170,13 @@ function QuickStart() {
           <div className={styles.quickStartStep}>
             <h3><Translate id="homepage.quickStart.step1.title">1. Fetch chart</Translate></h3>
             <CodeBlock language="bash">
-              helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+              helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
             </CodeBlock>
           </div>
           <div className={styles.quickStartStep}>
             <h3><Translate id="homepage.quickStart.step2.title">2. Install</Translate></h3>
             <CodeBlock language="bash">
-              helm install varmor varmor-0.10.3.tgz --namespace varmor --create-namespace --set image.registry="elkeid-ap-southeast-1.cr.volces.com"
+              helm install varmor varmor-0.10.4.tgz --namespace varmor --create-namespace --set image.registry="elkeid-ap-southeast-1.cr.volces.com"
             </CodeBlock>
           </div>
           <div className={styles.quickStartStep}>

--- a/website/versioned_docs/version-v0.10/getting_started/installation.md
+++ b/website/versioned_docs/version-v0.10/getting_started/installation.md
@@ -22,13 +22,13 @@ vArmor can be deployed via a Helm chart which is the recommended and preferred m
 In order to install vArmor with Helm, first fetch the chart.
 
 ```
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 Then install it with helm optional [configurations](#configuration).
 
 ```
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com"
 ```
@@ -210,7 +210,7 @@ The NetworkProxy enforcer transparently redirects traffic by injecting iptables 
 You can use helm commands to upgrade, rollback, and perform other operations.
 
 ```bash
-helm upgrade varmor varmor-0.10.3.tgz \
+helm upgrade varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com" \
     --set bpfLsmEnforcer.enabled=true \

--- a/website/versioned_docs/version-v0.10/getting_started/installation.md
+++ b/website/versioned_docs/version-v0.10/getting_started/installation.md
@@ -156,6 +156,55 @@ You can use the following option to change this behavior. Default: disabled.
 ```
 
 
+### Dynamic Configuration
+
+Besides the install-time Helm options above, vArmor ships a runtime-reloadable configuration carried by the `varmor-config` ConfigMap in vArmor's namespace. The manager watches this ConfigMap via an informer and hot-reloads changes **without a restart**. If the ConfigMap is absent or malformed, the manager falls back to the built-in defaults (which are identical to the values shipped by the chart). You can seed its initial content through the `dynamicConfig` value at install time, or edit the ConfigMap directly afterwards.
+
+```bash
+kubectl -n varmor edit configmap varmor-config
+```
+
+#### Default Resources of the NetworkProxy Sidecar
+You can set the cluster-wide default resource requests/limits for the injected NetworkProxy (Envoy) sidecar, so an administrator can tune sidecar resources once instead of setting `.spec.policy.networkProxy.resources` on every policy.
+
+The injector resolves the final resources with a three-layer, field-level merge chain, where each leaf value (`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`) falls back independently:
+
+> per-policy override (`.spec.policy.networkProxy.resources`) > this cluster-global config > built-in defaults
+
+Two independent, MITM-aware tiers are provided, because a MITM sidecar runs heavier (double TLS handshakes). A MITM sidecar reads **only** the `mitm` tier and a non-MITM sidecar reads **only** the `nonMitm` tier — the tiers are **not** inherited from each other. The built-in defaults are:
+
+| Tier | CPU requests | Memory requests | CPU limits | Memory limits |
+|------|-------------|----------------|-----------|--------------|
+| `nonMitm` | 50m | 64Mi | 500m | 256Mi |
+| `mitm` | 100m | 128Mi | 1000m | 512Mi |
+
+```bash
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.cpu="50m" \
+--set dynamicConfig.networkProxy.defaultResources.nonMitm.requests.memory="64Mi" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.cpu="1000m" \
+--set dynamicConfig.networkProxy.defaultResources.mitm.limits.memory="512Mi"
+```
+
+Notes:
+* Always quote quantities as strings (e.g. `"500m"`, `"256Mi"`). An unquoted bare number is parsed as an integer, so `memory: 100` means **100 bytes**, not 100Mi.
+* The tier keys must be spelled exactly `nonMitm` and `mitm`. A misspelled tier key is silently ignored and that tier falls back to the built-in defaults.
+* Invalid entries (an unknown resource name, an unparseable quantity, a non-positive value, or a limit set below its request in the same tier) are ignored and logged by the manager at load time; that field falls back to its built-in default.
+
+#### Micro-VM (Kata) Detection for NetworkProxy Auditing
+The NetworkProxy enforcer persists egress violation audit logs through its Envoy sidecar. Under a runc runtime, Envoy streams the records over a node-level hostPath Unix socket to the `varmor-agent` DaemonSet. Under a micro-VM runtime (kata / serverless sandbox) the sidecar runs inside a micro-VM, so that hostPath socket cannot cross the VM boundary (and is rejected at admission by some serverless providers). For such workloads vArmor omits the hostPath volume/mount and starts an in-sidecar audit sink that binds the socket in the container's own rootfs and writes the container-local `/var/log/varmor/violations.log` — producing byte-identical normalized records to the runc path.
+
+The `microVMDetection` config tells the injector which workloads run under a micro-VM runtime. A workload matches if its `runtimeClassName` is listed **OR** any annotation rule matches **OR** any label rule matches (for annotation/label rules, an empty value matches on key presence alone; a non-empty value must match exactly). The built-in defaults already cover upstream kata and the major cloud serverless runtimes:
+
+* `runtimeClassNames`: `kata`, `kata-qemu`, `kata-clh`
+* annotation: `vke.volcengine.com/burst-to-vci=enforce` (Volcengine VKE burst-to-VCI)
+* label: `alibabacloud.com/eci=true` (Alibaba Cloud ECI)
+
+To extend the rules for a custom micro-VM runtime, edit the `varmor-config` ConfigMap or set the `dynamicConfig.microVMDetection` values at install time.
+
+#### iptables Backend for NetworkProxy Traffic Redirection
+The NetworkProxy enforcer transparently redirects traffic by injecting iptables rules through an init container. Starting from the `proxyinit:v0.2` image, vArmor automatically detects the iptables backend (`legacy` vs `nft`) already in use in the target network namespace and drives the matching backend, instead of hardcoding one. This prevents traffic from being silently blackholed in shared-netns setups — for example a kata Pod whose netns is also programmed by a PaaS mesh init using the `legacy` backend. On a fresh netns it defaults to `nft` (matching prior behaviour); if both backends already carry rules it aborts with a `CONFLICT` rather than guessing. This is fully automatic and requires no configuration; just make sure the chart pulls `proxyinit:v0.2` or later.
+
+
 ## Upgrade
 
 You can use helm commands to upgrade, rollback, and perform other operations.

--- a/website/versioned_docs/version-v0.10/getting_started/interface_specification.md
+++ b/website/versioned_docs/version-v0.10/getting_started/interface_specification.md
@@ -257,6 +257,8 @@ Built-in defaults:
 | Non-MITM | 50m | 64Mi | 500m | 256Mi |
 | MITM | 100m | 128Mi | 1000m | 512Mi |
 
+> The resolved resources follow a three-layer, field-level merge chain: this per-policy override > the cluster-global default set in the `varmor-config` ConfigMap > the built-in defaults above. See [Default Resources of the NetworkProxy Sidecar](./installation.md#default-resources-of-the-networkproxy-sidecar) for the cluster-global configuration.
+
 ## NetworkProxyRules
 
 | Field | Description |

--- a/website/versioned_docs/version-v0.10/getting_started/usage_instructions.md
+++ b/website/versioned_docs/version-v0.10/getting_started/usage_instructions.md
@@ -41,6 +41,7 @@ Notes:
 * Limited by the principle and performance impact of Seccomp, you can only use `auditViolations=true` and `allowViolations=true` in combination to implement the audit-only mode (observation mode) for the Seccomp enforcer when there is no policy in the BehaviorModeling mode.
 * Limited by the principle of the AppArmor LSM and Seccomp, when using the AppArmor or Seccomp enforcer, it may not be possible to associate container and Pod information for the short-lived processes.
 * The NetworkProxy enforcer reports egress traffic audit events through its Envoy sidecar. Because these events are produced by the proxy at the Pod granularity, they only carry Pod-level identity (`nodeName`, `podName`, `podNamespace`, `podUID`).
+* For the NetworkProxy enforcer, the way violation records reach `/var/log/varmor/violations.log` depends on the runtime. Under runc, the Envoy sidecar streams them to the node-level `varmor-agent`, which writes the log on the host. Under a micro-VM runtime (kata / serverless sandbox), an in-sidecar audit sink writes the log inside the container's own filesystem instead (the records are byte-identical). Whether a workload is treated as micro-VM is decided by the `microVMDetection` rules in the `varmor-config` ConfigMap; see [Micro-VM (Kata) Detection for NetworkProxy Auditing](../getting_started/installation.md#micro-vm-kata-detection-for-networkproxy-auditing).
 
 ```json
 {
@@ -60,6 +61,9 @@ Notes:
   "enforcer": "BPF",
   "action": "DENIED",
   "profileName": "varmor-demo-demo-2",
+  "policyKind": "VarmorPolicy",
+  "policyName": "demo-2",
+  "policyNamespace": "demo",
   "event": {
     "operation": "File",
     "permissions": [

--- a/website/versioned_docs/version-v0.10/guides/policy_tools/policy_advisor.md
+++ b/website/versioned_docs/version-v0.10/guides/policy_tools/policy_advisor.md
@@ -19,6 +19,8 @@ Filter out the conflicted built-in rules with behavior data to make the policy t
 
 `policy-advisor.py AppArmor,BPF -f share-containers-pid-ns -c sys_admin,net_admin,kill -m data.json`
 
+> When matching behavior data against rules such as `disable-shell`, the advisor keys off both the executable basename and its file-extension token. So a shell recorded only as a script path (e.g. `/var/lib/cilium/bpf/init.sh`, with no `sh`/`bash`/`dash` binary) is still detected as a conflict via its `.sh` extension, and the conflicting rule is filtered out.
+
 
 ## Usage
 ```

--- a/website/versioned_docs/version-v0.10/introduction.mdx
+++ b/website/versioned_docs/version-v0.10/introduction.mdx
@@ -93,14 +93,14 @@ The prerequisites required by different enforcers are as shown in the following 
 ## Quick Start
 ### Step 1. Fetch chart
 ```
-helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.3
+helm pull oci://elkeid-ap-southeast-1.cr.volces.com/varmor/varmor --version 0.10.4
 ```
 
 ### Step 2. Install
 The default configuration enables the AppArmor and Seccomp enforcers. Please refer to the documentation for more [configuration options](getting_started/installation#configuration).
 
 ```
-helm install varmor varmor-0.10.3.tgz \
+helm install varmor varmor-0.10.4.tgz \
     --namespace varmor --create-namespace \
     --set image.registry="elkeid-ap-southeast-1.cr.volces.com"
 ```


### PR DESCRIPTION
## What this PR does

Documents the NetworkProxy and policy-advisor features shipped after v0.10.3,
and prepares the repository for the v0.10.4 release. Covers EN/zh across both
`docs/` and `website/` (current version only).

## Changes

### Installation — Dynamic Configuration
- Add a **Dynamic Configuration** section covering the `varmor-config` ConfigMap
  (hot-reloadable, no restart required; falls back to built-in defaults when
  missing or malformed).
- Document **NetworkProxy sidecar default resources**: independent `nonMitm` /
  `mitm` tiers, with a **three-tier, field-level merge chain** resolving each
  leaf field (`requests.cpu` / `requests.memory` / `limits.cpu` / `limits.memory`):
  > Policy-level override > Cluster-level global config (`varmor-config`) > Built-in default
- Document **micro-VM (Kata / Serverless) detection** via `microVMDetection`
  (`runtimeClassNames`, annotation, and label rules; built-in defaults cover
  upstream Kata plus major cloud-vendor Serverless runtimes).
- Document **iptables backend auto-detection** (`legacy` vs. `nft`) introduced
  in `proxyinit:v0.2`, including the explicit `CONFLICT` abort behavior.

### Interface specification
- Note the three-tier resource merge chain and link to the cluster-global
  default-resources section.

### Usage instructions
- Document the **runc vs. micro-VM audit-log write paths** (node-level hostPath
  UDS + gRPC ALS to `varmor-agent` for runc; in-sidecar ALS sink for micro-VMs;
  both produce byte-for-byte identical records at `/var/log/varmor/violations.log`).
- Document the Pod-level identity fields carried on each audit record
  (`policyKind` / `policyName` / `policyNamespace`, `nodeName`, `podName`,
  `podNamespace`, `podUID`).

### policy-advisor
- Document `.sh` extension detection for shell-usage conflicts, so rules such
  as `disable-shell` match on **both the executable basename and its file
  extension** (e.g. `/var/lib/cilium/bpf/init.sh` is now correctly detected).

### Release preparation
- Bump the Helm chart / install references from `0.10.3` → `0.10.4` across
  `README.ja.md`, `docs/README.md`, `docs/README.zh_CN.md`, and related docs.
- Add the v0.10.4 release overview blog in EN and zh under `website/`.