### PR TITLE
policy: reject removal of immutable proxy config

### DIFF
--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -188,8 +188,11 @@ func ValidateUpdatePolicy(policy interface{}, oldEnforcer string, oldTarget varm
 	// hot-reloaded. Changing them would cause a mismatch between the iptables REDIRECT
 	// target and the Envoy listener port in existing Pods.
 	// When oldProxyConfig is nil (controller path), this check is skipped.
-	if oldProxyConfig != nil && newSpec.Policy.NetworkProxyConfig != nil {
+	if oldProxyConfig != nil {
 		newPC := newSpec.Policy.NetworkProxyConfig
+		if newPC == nil {
+			newPC = &varmor.NetworkProxyConfig{}
+		}
 		if !proxyConfigImmutableFieldsEqual(oldProxyConfig, newPC) {
 			return false, "Modifying proxyUID, proxyPort, or proxyAdminPort is not allowed after the policy is created. You need to recreate the policy object."
 		}

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -189,11 +189,7 @@ func ValidateUpdatePolicy(policy interface{}, oldEnforcer string, oldTarget varm
 	// target and the Envoy listener port in existing Pods.
 	// When oldProxyConfig is nil (controller path), this check is skipped.
 	if oldProxyConfig != nil {
-		newPC := newSpec.Policy.NetworkProxyConfig
-		if newPC == nil {
-			newPC = &varmor.NetworkProxyConfig{}
-		}
-		if !proxyConfigImmutableFieldsEqual(oldProxyConfig, newPC) {
+		if !proxyConfigImmutableFieldsEqual(oldProxyConfig, newSpec.Policy.NetworkProxyConfig) {
 			return false, "Modifying proxyUID, proxyPort, or proxyAdminPort is not allowed after the policy is created. You need to recreate the policy object."
 		}
 	}
@@ -272,12 +268,34 @@ func ValidateUpdatePolicy(policy interface{}, oldEnforcer string, oldTarget varm
 	return true, ""
 }
 
-// proxyConfigImmutableFieldsEqual compares the immutable fields of two
-// NetworkProxyConfig values. Returns true if they are equal or both nil.
+// proxyConfigImmutableFieldsEqual compares the effective immutable fields of
+// two NetworkProxyConfig values after applying their runtime defaults.
 func proxyConfigImmutableFieldsEqual(old, new *varmor.NetworkProxyConfig) bool {
-	return ptrInt64Equal(old.ProxyUID, new.ProxyUID) &&
-		ptrUint16Equal(old.ProxyPort, new.ProxyPort) &&
-		ptrUint16Equal(old.ProxyAdminPort, new.ProxyAdminPort)
+	oldProxyUID, oldProxyPort, oldProxyAdminPort := normalizedProxyConfigImmutableFields(old)
+	newProxyUID, newProxyPort, newProxyAdminPort := normalizedProxyConfigImmutableFields(new)
+
+	return oldProxyUID == newProxyUID &&
+		oldProxyPort == newProxyPort &&
+		oldProxyAdminPort == newProxyAdminPort
+}
+
+func normalizedProxyConfigImmutableFields(config *varmor.NetworkProxyConfig) (int64, uint16, uint16) {
+	proxyUID := varmorconfig.DefaultProxyUID
+	proxyPort := varmorconfig.DefaultProxyPort
+	proxyAdminPort := varmorconfig.DefaultProxyAdminPort
+	if config != nil {
+		if config.ProxyUID != nil {
+			proxyUID = *config.ProxyUID
+		}
+		if config.ProxyPort != nil {
+			proxyPort = *config.ProxyPort
+		}
+		if config.ProxyAdminPort != nil {
+			proxyAdminPort = *config.ProxyAdminPort
+		}
+	}
+
+	return proxyUID, proxyPort, proxyAdminPort
 }
 
 // validateNetworkProxyEgressForSpec validates NetworkProxy egress rules
@@ -298,26 +316,6 @@ func validateNetworkProxyEgressForSpec(spec *varmor.VarmorPolicySpec) (bool, str
 		}
 	}
 	return true, ""
-}
-
-func ptrInt64Equal(a, b *int64) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return *a == *b
-}
-
-func ptrUint16Equal(a, b *uint16) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return *a == *b
 }
 
 // containsYAMLUnsafeChars reports whether s contains any character that is

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -450,6 +450,63 @@ func TestValidateUpdatePolicy_ValidUpdate(t *testing.T) {
 	assert.Equal(t, "", message, "Validation passes when validation passes")
 }
 
+func TestValidateUpdatePolicy_RemoveNetworkProxyConfig(t *testing.T) {
+	proxyUID := int64(2000)
+	proxyPort := uint16(16001)
+	proxyAdminPort := uint16(16000)
+	tests := []struct {
+		name           string
+		oldProxyConfig *varmor.NetworkProxyConfig
+		valid          bool
+	}{
+		{
+			name: "custom immutable fields",
+			oldProxyConfig: &varmor.NetworkProxyConfig{
+				ProxyUID:       &proxyUID,
+				ProxyPort:      &proxyPort,
+				ProxyAdminPort: &proxyAdminPort,
+			},
+			valid: false,
+		},
+		{
+			name:           "default immutable fields",
+			oldProxyConfig: &varmor.NetworkProxyConfig{},
+			valid:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := &varmor.VarmorPolicy{
+				Spec: varmor.VarmorPolicySpec{
+					Target: varmor.Target{
+						Kind: "Deployment",
+						Name: "test-deployment",
+					},
+					Policy: varmor.Policy{
+						Enforcer: "AppArmor",
+						Mode:     varmor.RuntimeDefaultMode,
+					},
+				},
+				Status: varmor.VarmorPolicyStatus{Phase: varmor.VarmorPolicyProtecting},
+			}
+
+			valid, message := ValidateUpdatePolicy(
+				policy,
+				"AppArmor",
+				policy.Spec.Target,
+				tt.oldProxyConfig,
+			)
+			assert.Equal(t, tt.valid, valid)
+			if tt.valid {
+				assert.Empty(t, message)
+			} else {
+				assert.Contains(t, message, "Modifying proxyUID, proxyPort, or proxyAdminPort")
+			}
+		})
+	}
+}
+
 // TestValidateUpdatePolicy_UnsupportedPolicyType tests unsupported policy type
 func TestValidateUpdatePolicy_UnsupportedPolicyType(t *testing.T) {
 	invalidPolicy := "invalid policy type"

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	varmor "github.com/bytedance/vArmor/apis/varmor/v1beta1"
+	varmorconfig "github.com/bytedance/vArmor/internal/config"
 )
 
 // TestValidateAddPolicy_ValidVarmorPolicy tests valid VarmorPolicy validation
@@ -451,27 +452,51 @@ func TestValidateUpdatePolicy_ValidUpdate(t *testing.T) {
 }
 
 func TestValidateUpdatePolicy_RemoveNetworkProxyConfig(t *testing.T) {
-	proxyUID := int64(2000)
-	proxyPort := uint16(16001)
-	proxyAdminPort := uint16(16000)
+	defaultProxyUID := varmorconfig.DefaultProxyUID
+	defaultProxyPort := varmorconfig.DefaultProxyPort
+	defaultProxyAdminPort := varmorconfig.DefaultProxyAdminPort
+	customProxyUID := int64(2000)
+	customProxyPort := uint16(16001)
+	customProxyAdminPort := uint16(16000)
 	tests := []struct {
 		name           string
 		oldProxyConfig *varmor.NetworkProxyConfig
 		valid          bool
 	}{
 		{
-			name: "custom immutable fields",
+			name:           "implicit defaults",
+			oldProxyConfig: &varmor.NetworkProxyConfig{},
+			valid:          true,
+		},
+		{
+			name: "explicit defaults",
 			oldProxyConfig: &varmor.NetworkProxyConfig{
-				ProxyUID:       &proxyUID,
-				ProxyPort:      &proxyPort,
-				ProxyAdminPort: &proxyAdminPort,
+				ProxyUID:       &defaultProxyUID,
+				ProxyPort:      &defaultProxyPort,
+				ProxyAdminPort: &defaultProxyAdminPort,
+			},
+			valid: true,
+		},
+		{
+			name: "custom proxy UID",
+			oldProxyConfig: &varmor.NetworkProxyConfig{
+				ProxyUID: &customProxyUID,
 			},
 			valid: false,
 		},
 		{
-			name:           "default immutable fields",
-			oldProxyConfig: &varmor.NetworkProxyConfig{},
-			valid:          true,
+			name: "custom proxy port",
+			oldProxyConfig: &varmor.NetworkProxyConfig{
+				ProxyPort: &customProxyPort,
+			},
+			valid: false,
+		},
+		{
+			name: "custom proxy admin port",
+			oldProxyConfig: &varmor.NetworkProxyConfig{
+				ProxyAdminPort: &customProxyAdminPort,
+			},
+			valid: false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- treat a missing new `networkProxyConfig` as an empty configuration when comparing immutable proxy settings
- reject removal when the existing policy uses custom proxy UID or ports
- preserve valid removal when the existing policy already uses all defaults
- add focused update-validation regression coverage

## Root cause

The update validator compared immutable proxy fields only when both the old and new `NetworkProxyConfig` pointers were non-nil. Removing the new object skipped the comparison even though the effective proxy settings changed back to defaults, which could leave existing Pods' iptables redirects inconsistent with Envoy's listener settings.

Fixes #368

## Verification

- `go test -mod=readonly ./internal/policy -run 'TestValidateUpdatePolicy_(ValidUpdate|RemoveNetworkProxyConfig)$' -count=1`
- `go test -mod=readonly ./internal/policy -count=1`
- `go vet -mod=readonly ./internal/policy`
- `make test` in `golang:1.25-bookworm` with `libseccomp-dev` and `libapparmor-dev`; an empty `/var/log/kern.log` was provided for the existing journald test fixture