### PR TITLE
policy: synchronize behavior subscriber registries

### DIFF
--- a/pkg/processtracer/subscriber_race_test.go
+++ b/pkg/processtracer/subscriber_race_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestProcessEventChs_ConcurrentAccess(t *testing.T) {
+	tracer := &ProcessTracer{processEventChs: make(map[string]chan<- BpfProcessEvent)}
+	eventCh := make(chan BpfProcessEvent, 1)
+	tracer.processEventChs["keepalive"] = eventCh
+
+	const workers = 8
+	const iterations = 500
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(2)
+		go func(id int) {
+			defer wg.Done()
+			name := fmt.Sprintf("subscriber-%d", id)
+			for i := 0; i < iterations; i++ {
+				tracer.AddProcessEventNotifyCh(name, &eventCh)
+				tracer.DeleteProcessEventNotifyCh(name)
+			}
+		}(worker)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				tracer.snapshotProcessEventChs()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(tracer.snapshotProcessEventChs()) != 1 {
+		t.Fatal("keepalive subscriber was unexpectedly removed")
+	}
+}

--- a/pkg/processtracer/tracer.go
+++ b/pkg/processtracer/tracer.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
@@ -32,6 +33,7 @@ type ProcessTracer struct {
 	execLink        link.Link
 	forkLink        link.Link
 	reader          *perf.Reader
+	chsMu           sync.RWMutex
 	processEventChs map[string]chan<- BpfProcessEvent
 	tracing         bool
 	log             logr.Logger
@@ -74,6 +76,9 @@ func (tracer *ProcessTracer) Close() {
 }
 
 func (tracer *ProcessTracer) AddProcessEventNotifyCh(subscriber string, processEventCh *chan BpfProcessEvent) {
+	tracer.chsMu.Lock()
+	defer tracer.chsMu.Unlock()
+
 	if processEventCh != nil {
 		tracer.processEventChs[subscriber] = *processEventCh
 	}
@@ -88,12 +93,26 @@ func (tracer *ProcessTracer) AddProcessEventNotifyCh(subscriber string, processE
 }
 
 func (tracer *ProcessTracer) DeleteProcessEventNotifyCh(subscriber string) {
+	tracer.chsMu.Lock()
+	defer tracer.chsMu.Unlock()
+
 	delete(tracer.processEventChs, subscriber)
 
 	if len(tracer.processEventChs) == 0 && tracer.tracing {
 		tracer.stopTracing()
 		tracer.tracing = false
 	}
+}
+
+func (tracer *ProcessTracer) snapshotProcessEventChs() []chan<- BpfProcessEvent {
+	tracer.chsMu.RLock()
+	defer tracer.chsMu.RUnlock()
+
+	chs := make([]chan<- BpfProcessEvent, 0, len(tracer.processEventChs))
+	for _, ch := range tracer.processEventChs {
+		chs = append(chs, ch)
+	}
+	return chs
 }
 
 func (tracer *ProcessTracer) startTracing() error {
@@ -195,7 +214,7 @@ func (tracer *ProcessTracer) handleBpfEvents() {
 			continue
 		}
 
-		for _, eventCh := range tracer.processEventChs {
+		for _, eventCh := range tracer.snapshotProcessEventChs() {
 			eventCh <- event
 		}
 	}

--- a/pkg/runtime/monitor.go
+++ b/pkg/runtime/monitor.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -41,6 +42,7 @@ type RuntimeMonitor struct {
 	runtimeConn       *grpc.ClientConn
 	running           bool
 	status            error
+	chsMu             sync.RWMutex
 	taskStartChs      map[string]chan<- varmortypes.ContainerInfo
 	taskDeleteChs     map[string]chan<- varmortypes.ContainerInfo
 	taskDeleteSyncChs map[string]chan<- bool
@@ -83,6 +85,9 @@ func (monitor *RuntimeMonitor) AddTaskNotifyChs(
 	deleteCh *chan varmortypes.ContainerInfo,
 	deleteSynCh *chan bool) {
 
+	monitor.chsMu.Lock()
+	defer monitor.chsMu.Unlock()
+
 	if startCh != nil {
 		monitor.taskStartChs[subscriber] = *startCh
 	}
@@ -95,9 +100,45 @@ func (monitor *RuntimeMonitor) AddTaskNotifyChs(
 }
 
 func (monitor *RuntimeMonitor) DeleteTaskNotifyChs(subscriber string) {
+	monitor.chsMu.Lock()
+	defer monitor.chsMu.Unlock()
+
 	delete(monitor.taskStartChs, subscriber)
 	delete(monitor.taskDeleteChs, subscriber)
 	delete(monitor.taskDeleteSyncChs, subscriber)
+}
+
+func (monitor *RuntimeMonitor) snapshotTaskStartChs() []chan<- varmortypes.ContainerInfo {
+	monitor.chsMu.RLock()
+	defer monitor.chsMu.RUnlock()
+
+	chs := make([]chan<- varmortypes.ContainerInfo, 0, len(monitor.taskStartChs))
+	for _, ch := range monitor.taskStartChs {
+		chs = append(chs, ch)
+	}
+	return chs
+}
+
+func (monitor *RuntimeMonitor) snapshotTaskDeleteChs() []chan<- varmortypes.ContainerInfo {
+	monitor.chsMu.RLock()
+	defer monitor.chsMu.RUnlock()
+
+	chs := make([]chan<- varmortypes.ContainerInfo, 0, len(monitor.taskDeleteChs))
+	for _, ch := range monitor.taskDeleteChs {
+		chs = append(chs, ch)
+	}
+	return chs
+}
+
+func (monitor *RuntimeMonitor) snapshotTaskDeleteSyncChs() []chan<- bool {
+	monitor.chsMu.RLock()
+	defer monitor.chsMu.RUnlock()
+
+	chs := make([]chan<- bool, 0, len(monitor.taskDeleteSyncChs))
+	for _, ch := range monitor.taskDeleteSyncChs {
+		chs = append(chs, ch)
+	}
+	return chs
 }
 
 func (monitor *RuntimeMonitor) retrieveContainerInfo(containerInfo *varmortypes.ContainerInfo) error {
@@ -263,7 +304,7 @@ func (monitor *RuntimeMonitor) eventHandler(stopCh <-chan struct{}) {
 				info.ProfileName = extractVarmorProfileName(info)
 				if info.ProfileName != "" {
 					logger.V(2).Info("notify subscribers of the '/tasks/start'", "info", info)
-					for _, ch := range monitor.taskStartChs {
+					for _, ch := range monitor.snapshotTaskStartChs() {
 						ch <- info
 					}
 				}
@@ -282,7 +323,7 @@ func (monitor *RuntimeMonitor) eventHandler(stopCh <-chan struct{}) {
 				}
 
 				logger.V(2).Info("notify subscribers of the '/tasks/delete' event", "info", info)
-				for _, ch := range monitor.taskDeleteChs {
+				for _, ch := range monitor.snapshotTaskDeleteChs() {
 					ch <- info
 				}
 			}
@@ -308,7 +349,7 @@ func (monitor *RuntimeMonitor) eventHandler(stopCh <-chan struct{}) {
 				monitor.status = nil
 
 				logger.V(2).Info("notify subscribers to handle the containers that exit or are created while the monitor is offline")
-				for _, ch := range monitor.taskDeleteSyncChs {
+				for _, ch := range monitor.snapshotTaskDeleteSyncChs() {
 					ch <- true
 				}
 				monitor.CollectExistingTargetContainers()
@@ -380,7 +421,7 @@ func (monitor *RuntimeMonitor) CollectExistingTargetContainers() error {
 
 		info.ProfileName = extractVarmorProfileName(info)
 		if info.ProfileName != "" {
-			for _, ch := range monitor.taskStartChs {
+			for _, ch := range monitor.snapshotTaskStartChs() {
 				ch <- info
 			}
 		}

--- a/pkg/runtime/subscriber_race_test.go
+++ b/pkg/runtime/subscriber_race_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 vArmor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	varmortypes "github.com/bytedance/vArmor/pkg/types"
+)
+
+func TestTaskNotifyChs_ConcurrentAccess(t *testing.T) {
+	monitor := &RuntimeMonitor{
+		taskStartChs:      make(map[string]chan<- varmortypes.ContainerInfo),
+		taskDeleteChs:     make(map[string]chan<- varmortypes.ContainerInfo),
+		taskDeleteSyncChs: make(map[string]chan<- bool),
+	}
+	startCh := make(chan varmortypes.ContainerInfo, 1)
+	deleteCh := make(chan varmortypes.ContainerInfo, 1)
+	syncCh := make(chan bool, 1)
+	monitor.AddTaskNotifyChs("keepalive", &startCh, &deleteCh, &syncCh)
+
+	const workers = 8
+	const iterations = 500
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(2)
+		go func(id int) {
+			defer wg.Done()
+			name := fmt.Sprintf("subscriber-%d", id)
+			for i := 0; i < iterations; i++ {
+				monitor.AddTaskNotifyChs(name, &startCh, &deleteCh, &syncCh)
+				monitor.DeleteTaskNotifyChs(name)
+			}
+		}(worker)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				monitor.snapshotTaskStartChs()
+				monitor.snapshotTaskDeleteChs()
+				monitor.snapshotTaskDeleteSyncChs()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(monitor.snapshotTaskStartChs()) != 1 ||
+		len(monitor.snapshotTaskDeleteChs()) != 1 ||
+		len(monitor.snapshotTaskDeleteSyncChs()) != 1 {
+		t.Fatal("keepalive subscriber was unexpectedly removed")
+	}
+}


### PR DESCRIPTION
## Summary

- guard RuntimeMonitor task subscriber maps with an RWMutex
- guard ProcessTracer subscriber registration and count transitions with an RWMutex
- snapshot subscriber channels under a read lock and perform channel sends after releasing it
- add concurrent churn tests for both registries

## Root cause

BehaviorModeling starts and stops subscribers from the modeller goroutine while containerd and eBPF event goroutines iterate the same maps. Those unsynchronized reads and writes can race or terminate the agent with a concurrent map access fatal error.

The snapshot approach follows the existing Auditor subscriber fix: map access is protected, but a slow channel receiver cannot hold the registry lock and block subscriber updates.

Fixes #370

## Verification

- `go test -mod=readonly -race ./pkg/runtime ./pkg/processtracer -count=1`
- `go test -mod=readonly ./pkg/runtime ./pkg/processtracer -count=1`
- `go vet -mod=readonly ./pkg/runtime ./pkg/processtracer`
- `make test` in `golang:1.25-bookworm` with `libseccomp-dev` and `libapparmor-dev`; an empty `/var/log/kern.log` was provided for the existing journald test fixture