### PR TITLE
docs: correct NetworkProxy resource override path

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -159,11 +159,11 @@ kubectl -n varmor edit configmap varmor-config
 ```
 
 #### Default Resources of the NetworkProxy Sidecar
-You can set the cluster-wide default resource requests/limits for the injected NetworkProxy (Envoy) sidecar, so an administrator can tune sidecar resources once instead of setting `.spec.policy.networkProxy.resources` on every policy.
+You can set the cluster-wide default resource requests/limits for the injected NetworkProxy (Envoy) sidecar, so an administrator can tune sidecar resources once instead of setting `.spec.policy.networkProxyConfig.resources` on every policy.
 
 The injector resolves the final resources with a three-layer, field-level merge chain, where each leaf value (`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`) falls back independently:
 
-> per-policy override (`.spec.policy.networkProxy.resources`) > this cluster-global config > built-in defaults
+> per-policy override (`.spec.policy.networkProxyConfig.resources`) > this cluster-global config > built-in defaults
 
 Two independent, MITM-aware tiers are provided, because a MITM sidecar runs heavier (double TLS handshakes). A MITM sidecar reads **only** the `mitm` tier and a non-MITM sidecar reads **only** the `nonMitm` tier — the tiers are **not** inherited from each other. The built-in defaults are:
 

--- a/docs/getting_started/installation.zh_CN.md
+++ b/docs/getting_started/installation.zh_CN.md
@@ -159,11 +159,11 @@ kubectl -n varmor edit configmap varmor-config
 ```
 
 #### NetworkProxy Sidecar 的默认资源
-你可以为注入的 NetworkProxy(Envoy) sidecar 设置集群级的默认资源 requests/limits，这样管理员只需配置一次，而不必在每个策略上单独设置 `.spec.policy.networkProxy.resources`。
+你可以为注入的 NetworkProxy(Envoy) sidecar 设置集群级的默认资源 requests/limits，这样管理员只需配置一次，而不必在每个策略上单独设置 `.spec.policy.networkProxyConfig.resources`。
 
 注入器采用三层、字段级的合并链来解析最终资源，其中每个叶子字段(`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`)独立回退：
 
-> 策略级覆盖(`.spec.policy.networkProxy.resources`) > 本集群级全局配置 > 内置默认值
+> 策略级覆盖(`.spec.policy.networkProxyConfig.resources`) > 本集群级全局配置 > 内置默认值
 
 由于 MITM sidecar 负载更重(双向 TLS 握手)，配置分为两个相互独立且区分 MITM 的层级。MITM sidecar **只**读取 `mitm` 层，非 MITM sidecar **只**读取 `nonMitm` 层——两层之间**不会**相互继承。内置默认值如下：
 

--- a/website/blog/2026-08-04-0.10.4-overview/index.md
+++ b/website/blog/2026-08-04-0.10.4-overview/index.md
@@ -74,7 +74,7 @@ In the [future roadmap of v0.10.1](/blog/varmor-0.10.1-new-features-overview/), 
 
 vArmor adds a runtime hot-reloadable dynamic configuration, carried in the `varmor-config` ConfigMap in vArmor's namespace. The Manager watches this ConfigMap via an informer and hot-reloads on change **without a restart**; if the ConfigMap is missing or malformed, it falls back to the built-in defaults that are identical to the values shipped with the Chart.
 
-Administrators now only need to **configure once** to set default resource requests/limits for every NetworkProxy sidecar injected across the cluster, instead of setting `.spec.policy.networkProxy.resources` on each policy individually. The injector uses a **three-tier, field-level merge chain** to resolve the final resources, with each leaf field (`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`) falling back independently:
+Administrators now only need to **configure once** to set default resource requests/limits for every NetworkProxy sidecar injected across the cluster, instead of setting `.spec.policy.networkProxyConfig.resources` on each policy individually. The injector uses a **three-tier, field-level merge chain** to resolve the final resources, with each leaf field (`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`) falling back independently:
 
 > Policy-level override > Cluster-level global config (`varmor-config`) > Built-in default
 

--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -165,11 +165,11 @@ kubectl -n varmor edit configmap varmor-config
 ```
 
 #### Default Resources of the NetworkProxy Sidecar
-You can set the cluster-wide default resource requests/limits for the injected NetworkProxy (Envoy) sidecar, so an administrator can tune sidecar resources once instead of setting `.spec.policy.networkProxy.resources` on every policy.
+You can set the cluster-wide default resource requests/limits for the injected NetworkProxy (Envoy) sidecar, so an administrator can tune sidecar resources once instead of setting `.spec.policy.networkProxyConfig.resources` on every policy.
 
 The injector resolves the final resources with a three-layer, field-level merge chain, where each leaf value (`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`) falls back independently:
 
-> per-policy override (`.spec.policy.networkProxy.resources`) > this cluster-global config > built-in defaults
+> per-policy override (`.spec.policy.networkProxyConfig.resources`) > this cluster-global config > built-in defaults
 
 Two independent, MITM-aware tiers are provided, because a MITM sidecar runs heavier (double TLS handshakes). A MITM sidecar reads **only** the `mitm` tier and a non-MITM sidecar reads **only** the `nonMitm` tier — the tiers are **not** inherited from each other. The built-in defaults are:
 

--- a/website/i18n/zh-cn/docusaurus-plugin-content-blog/2026-08-04-0.10.4-overview/index.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-blog/2026-08-04-0.10.4-overview/index.md
@@ -74,7 +74,7 @@ NetworkProxy enforcer 通过 init 容器注入 iptables 规则来透明地重定
 
 vArmor 新增了一份运行时可热加载的动态配置，承载于 vArmor 所在命名空间下的 `varmor-config` ConfigMap 中。Manager 通过 informer 监听该 ConfigMap，变更时 **无需重启** 即可热加载；若 ConfigMap 缺失或格式非法，则回退到与 Chart 随附取值完全一致的内置默认值。
 
-管理员从此只需 **配置一次**，即可为整个集群注入的 NetworkProxy Sidecar 设置默认资源 requests/limits，而不必在每条策略上单独设置 `.spec.policy.networkProxy.resources`。注入器采用 **三层、字段级的合并链** 解析最终资源，每个叶子字段（`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`）独立回退：
+管理员从此只需 **配置一次**，即可为整个集群注入的 NetworkProxy Sidecar 设置默认资源 requests/limits，而不必在每条策略上单独设置 `.spec.policy.networkProxyConfig.resources`。注入器采用 **三层、字段级的合并链** 解析最终资源，每个叶子字段（`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`）独立回退：
 
 > 策略级覆盖 > 集群级全局配置（`varmor-config`） > 内置默认值
 

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/installation.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/getting_started/installation.md
@@ -162,11 +162,11 @@ kubectl -n varmor edit configmap varmor-config
 ```
 
 #### NetworkProxy Sidecar 的默认资源
-你可以为注入的 NetworkProxy(Envoy) sidecar 设置集群级的默认资源 requests/limits，这样管理员只需配置一次，而不必在每个策略上单独设置 `.spec.policy.networkProxy.resources`。
+你可以为注入的 NetworkProxy(Envoy) sidecar 设置集群级的默认资源 requests/limits，这样管理员只需配置一次，而不必在每个策略上单独设置 `.spec.policy.networkProxyConfig.resources`。
 
 注入器采用三层、字段级的合并链来解析最终资源，其中每个叶子字段(`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`)独立回退：
 
-> 策略级覆盖(`.spec.policy.networkProxy.resources`) > 本集群级全局配置 > 内置默认值
+> 策略级覆盖(`.spec.policy.networkProxyConfig.resources`) > 本集群级全局配置 > 内置默认值
 
 由于 MITM sidecar 负载更重(双向 TLS 握手)，配置分为两个相互独立且区分 MITM 的层级。MITM sidecar **只**读取 `mitm` 层，非 MITM sidecar **只**读取 `nonMitm` 层——两层之间**不会**相互继承。内置默认值如下：
 

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/installation.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/version-v0.10/getting_started/installation.md
@@ -162,11 +162,11 @@ kubectl -n varmor edit configmap varmor-config
 ```
 
 #### NetworkProxy Sidecar 的默认资源
-你可以为注入的 NetworkProxy(Envoy) sidecar 设置集群级的默认资源 requests/limits，这样管理员只需配置一次，而不必在每个策略上单独设置 `.spec.policy.networkProxy.resources`。
+你可以为注入的 NetworkProxy(Envoy) sidecar 设置集群级的默认资源 requests/limits，这样管理员只需配置一次，而不必在每个策略上单独设置 `.spec.policy.networkProxyConfig.resources`。
 
 注入器采用三层、字段级的合并链来解析最终资源，其中每个叶子字段(`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`)独立回退：
 
-> 策略级覆盖(`.spec.policy.networkProxy.resources`) > 本集群级全局配置 > 内置默认值
+> 策略级覆盖(`.spec.policy.networkProxyConfig.resources`) > 本集群级全局配置 > 内置默认值
 
 由于 MITM sidecar 负载更重(双向 TLS 握手)，配置分为两个相互独立且区分 MITM 的层级。MITM sidecar **只**读取 `mitm` 层，非 MITM sidecar **只**读取 `nonMitm` 层——两层之间**不会**相互继承。内置默认值如下：
 

--- a/website/versioned_docs/version-v0.10/getting_started/installation.md
+++ b/website/versioned_docs/version-v0.10/getting_started/installation.md
@@ -165,11 +165,11 @@ kubectl -n varmor edit configmap varmor-config
 ```
 
 #### Default Resources of the NetworkProxy Sidecar
-You can set the cluster-wide default resource requests/limits for the injected NetworkProxy (Envoy) sidecar, so an administrator can tune sidecar resources once instead of setting `.spec.policy.networkProxy.resources` on every policy.
+You can set the cluster-wide default resource requests/limits for the injected NetworkProxy (Envoy) sidecar, so an administrator can tune sidecar resources once instead of setting `.spec.policy.networkProxyConfig.resources` on every policy.
 
 The injector resolves the final resources with a three-layer, field-level merge chain, where each leaf value (`requests.cpu`/`requests.memory`/`limits.cpu`/`limits.memory`) falls back independently:
 
-> per-policy override (`.spec.policy.networkProxy.resources`) > this cluster-global config > built-in defaults
+> per-policy override (`.spec.policy.networkProxyConfig.resources`) > this cluster-global config > built-in defaults
 
 Two independent, MITM-aware tiers are provided, because a MITM sidecar runs heavier (double TLS handshakes). A MITM sidecar reads **only** the `mitm` tier and a non-MITM sidecar reads **only** the `nonMitm` tier — the tiers are **not** inherited from each other. The built-in defaults are:
 


### PR DESCRIPTION
## Summary

- correct the NetworkProxy resource override path in the installation guides
- update the matching current, versioned, localized, and v0.10.4 release blog sources
- keep the duplicated English and Chinese documentation sources synchronized

The documented JSON Patch path used `.spec.policy.networkProxy.resources`, but the v0.10.4 API exposes the configuration as `networkProxyConfig`. The corrected path is `.spec.policy.networkProxyConfig.resources`.

Fixes #372

## Verification

- `git grep -F '.spec.policy.networkProxy.resources' -- '*.md' '*.mdx'` returns no matches
- all 14 corrected paths match the `networkProxyConfig` and `resources` API JSON tags
- the current and v0.10 English copies match, as do the corresponding Chinese copies
- `npm run build` succeeded for both English and Chinese in an isolated `npm ci` tree (the build still reports pre-existing broken-link warnings unrelated to this change)