### PR TITLE
fix(networkproxy): preserve maximum port range end

### DIFF
--- a/internal/networkproxy/profile/renderer.go
+++ b/internal/networkproxy/profile/renderer.go
@@ -619,7 +619,7 @@ func renderPermissionRuleYAML(rule PermissionRule, indent int, rbacType string) 
 		sb.WriteString(fmt.Sprintf("%s- destination_port: %d\n", prefix, port))
 
 	case "destination_port_range":
-		rangeVal := rule.Value.(map[string]uint16)
+		rangeVal := rule.Value.(map[string]uint32)
 		sb.WriteString(fmt.Sprintf("%s- destination_port_range:\n", prefix))
 		sb.WriteString(fmt.Sprintf("%s    start: %d\n", prefix, rangeVal["start"]))
 		sb.WriteString(fmt.Sprintf("%s    end: %d\n", prefix, rangeVal["end"]))

--- a/internal/networkproxy/profile/translator.go
+++ b/internal/networkproxy/profile/translator.go
@@ -1216,9 +1216,9 @@ func portToPermissionRules(ports []varmor.Port) []PermissionRule {
 		if p.EndPort > 0 && p.EndPort != p.Port {
 			rules = append(rules, PermissionRule{
 				Type: "destination_port_range",
-				Value: map[string]uint16{
-					"start": p.Port,
-					"end":   p.EndPort + 1,
+				Value: map[string]uint32{
+					"start": uint32(p.Port),
+					"end":   uint32(p.EndPort) + 1,
 				},
 			})
 		} else {

--- a/internal/networkproxy/profile/translator_test.go
+++ b/internal/networkproxy/profile/translator_test.go
@@ -338,19 +338,34 @@ func TestAuditOnlyRule(t *testing.T) {
 }
 
 func TestPortRange(t *testing.T) {
-	egress := &varmor.NetworkProxyEgress{
-		DefaultAction: "deny",
-		Rules: []varmor.NetworkProxyEgressRule{
-			{Qualifiers: []string{"allow"}, IP: "10.0.0.1", Ports: []varmor.Port{{Port: 8000, EndPort: 9000}}},
-		},
+	tests := []struct {
+		name      string
+		port      uint16
+		endPort   uint16
+		wantStart string
+		wantEnd   string
+	}{
+		{name: "regular range", port: 8000, endPort: 9000, wantStart: "start: 8000", wantEnd: "end: 9001"},
+		{name: "maximum port", port: 65534, endPort: 65535, wantStart: "start: 65534", wantEnd: "end: 65536"},
 	}
-	result, err := TranslateEgressRules(egress, 1, 15001, nil, testIPStack, AuditSinkConfig{})
-	if err != nil {
-		t.Fatalf("TranslateEgressRules failed: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			egress := &varmor.NetworkProxyEgress{
+				DefaultAction: "deny",
+				Rules: []varmor.NetworkProxyEgressRule{
+					{Qualifiers: []string{"allow"}, IP: "10.0.0.1", Ports: []varmor.Port{{Port: tt.port, EndPort: tt.endPort}}},
+				},
+			}
+			result, err := TranslateEgressRules(egress, 1, 15001, nil, testIPStack, AuditSinkConfig{})
+			if err != nil {
+				t.Fatalf("TranslateEgressRules failed: %v", err)
+			}
+			assertContains(t, result.LDS, "destination_port_range:", "port range present")
+			assertContains(t, result.LDS, tt.wantStart, "port range start")
+			assertContains(t, result.LDS, tt.wantEnd, "port range end (exclusive)")
+		})
 	}
-	assertContains(t, result.LDS, "destination_port_range:", "port range present")
-	assertContains(t, result.LDS, "start: 8000", "port range start")
-	assertContains(t, result.LDS, "end: 9001", "port range end (exclusive)")
 }
 
 func TestWildcardDomain(t *testing.T) {


### PR DESCRIPTION
## Summary

- widen the internal NetworkProxy range representation so the exclusive upper bound can hold `65536`
- keep single-port matchers and the public `uint16` port API unchanged
- add regression coverage for both an ordinary range and the maximum valid port boundary

Without this change, an API-valid range ending at port `65535` wraps its generated Envoy `destination_port_range.end` to `0`.

Fixes #374

## Verification

- `go test -mod=readonly ./internal/networkproxy/profile -run TestPortRange -count=1`
- `go test -mod=readonly ./internal/networkproxy/profile -count=1`
- `go vet -mod=readonly ./internal/networkproxy/profile`
- `git diff --check`