### PR TITLE
test: fix invalid YAML in performance policies

### DIFF
--- a/test/perf/policy/apparmor-enhance.yaml
+++ b/test/perf/policy/apparmor-enhance.yaml
@@ -20,11 +20,11 @@ spec:
       - disallow-access-procfs-root
       attackProtectionRules:
       - rules:
-        - mitigate-disk-device-number-leak	
+        - mitigate-disk-device-number-leak
         - mitigate-sa-leak
-        - mitigate-overlayfs-leak	
-        - mitigate-host-ip-leak	
-        - disallow-metadata-service	
+        - mitigate-overlayfs-leak
+        - mitigate-host-ip-leak
+        - disallow-metadata-service
       vulMitigationRules:
-      - cgroups-lxcfs-escape-mitigation	
-      - runc-override-mitigation	
+      - cgroups-lxcfs-escape-mitigation
+      - runc-override-mitigation

--- a/test/perf/policy/bpf-enhance.yaml
+++ b/test/perf/policy/bpf-enhance.yaml
@@ -20,11 +20,11 @@ spec:
       - disallow-access-procfs-root
       attackProtectionRules:
       - rules:
-        - mitigate-disk-device-number-leak	
+        - mitigate-disk-device-number-leak
         - mitigate-sa-leak
-        - mitigate-overlayfs-leak	
-        - mitigate-host-ip-leak	
-        - disallow-metadata-service	
+        - mitigate-overlayfs-leak
+        - mitigate-host-ip-leak
+        - disallow-metadata-service
       vulMitigationRules:
-      - cgroups-lxcfs-escape-mitigation	
-      - runc-override-mitigation	
+      - cgroups-lxcfs-escape-mitigation
+      - runc-override-mitigation


### PR DESCRIPTION
## Summary

- remove invalid trailing tab characters from the AppArmor and BPF EnhanceProtect performance policies
- preserve every policy key and value
- make the fixtures consumable by the UnixBench, SysBench, and Phoronix benchmark scripts

Fixes #376

## Verification

- parsed all 103 non-template YAML/YML files with PyYAML; 23 Helm-template files were detected and skipped, with zero parse errors
- `rg -n "\t" -g '*.yaml' -g '*.yml' .` returns no matches
- both changed documents are semantically equal to their baseline forms after removing tabs
- `git diff --check`

The cluster-backed performance benchmarks were not run because this Windows audit environment does not provide the required Kubernetes/Linux benchmark setup.