### PR TITLE
fix(processtracer): synchronize subscriber lifecycle

### DIFF
--- a/pkg/processtracer/subscriber_race_test.go
+++ b/pkg/processtracer/subscriber_race_test.go
@@ -15,13 +15,22 @@
 package tracer
 
 import (
+	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
+
+	"github.com/go-logr/logr"
 )
 
 func TestProcessEventChs_ConcurrentAccess(t *testing.T) {
-	tracer := &ProcessTracer{processEventChs: make(map[string]chan<- BpfProcessEvent)}
+	tracer := &ProcessTracer{
+		processEventChs: make(map[string]chan<- BpfProcessEvent),
+		tracing:         true,
+		stopTracingFn:   func() error { return nil },
+		log:             logr.Discard(),
+	}
 	eventCh := make(chan BpfProcessEvent, 1)
 	tracer.processEventChs["keepalive"] = eventCh
 
@@ -49,5 +58,311 @@ func TestProcessEventChs_ConcurrentAccess(t *testing.T) {
 
 	if len(tracer.snapshotProcessEventChs()) != 1 {
 		t.Fatal("keepalive subscriber was unexpectedly removed")
+	}
+}
+
+func TestAddProcessEventNotifyCh_IdempotentStart(t *testing.T) {
+	var starts atomic.Int32
+	tracer := &ProcessTracer{
+		processEventChs: make(map[string]chan<- BpfProcessEvent),
+		startTracingFn: func() error {
+			starts.Add(1)
+			return nil
+		},
+		log: logr.Discard(),
+	}
+	firstCh := make(chan BpfProcessEvent, 1)
+	secondCh := make(chan BpfProcessEvent, 1)
+
+	tracer.AddProcessEventNotifyCh("subscriber", &firstCh)
+	tracer.AddProcessEventNotifyCh("subscriber", &secondCh)
+
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("tracing started %d times, want 1", got)
+	}
+	if !tracer.tracing {
+		t.Fatal("tracing was not marked active after a successful start")
+	}
+	chs := tracer.snapshotProcessEventChs()
+	if len(chs) != 1 || chs[0] != secondCh {
+		t.Fatal("re-registering a subscriber did not replace its notification channel")
+	}
+}
+
+func TestAddProcessEventNotifyCh_StartFailureCanRetry(t *testing.T) {
+	var starts atomic.Int32
+	tracer := &ProcessTracer{
+		processEventChs: make(map[string]chan<- BpfProcessEvent),
+		startTracingFn: func() error {
+			if starts.Add(1) == 1 {
+				return errors.New("injected start failure")
+			}
+			return nil
+		},
+		log: logr.Discard(),
+	}
+	eventCh := make(chan BpfProcessEvent, 1)
+
+	tracer.AddProcessEventNotifyCh("subscriber", &eventCh)
+	if tracer.tracing {
+		t.Fatal("tracing was marked active after start failed")
+	}
+
+	tracer.AddProcessEventNotifyCh("subscriber", &eventCh)
+	if !tracer.tracing {
+		t.Fatal("tracing was not marked active after retry succeeded")
+	}
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("tracing start attempted %d times, want 2", got)
+	}
+}
+
+func TestProcessEventNotifyCh_ReAddAfterDeleteRestartsTracing(t *testing.T) {
+	var starts atomic.Int32
+	var stops atomic.Int32
+	tracer := &ProcessTracer{
+		processEventChs: make(map[string]chan<- BpfProcessEvent),
+		startTracingFn: func() error {
+			starts.Add(1)
+			return nil
+		},
+		stopTracingFn: func() error {
+			stops.Add(1)
+			return nil
+		},
+		log: logr.Discard(),
+	}
+	eventCh := make(chan BpfProcessEvent, 1)
+
+	tracer.AddProcessEventNotifyCh("subscriber", &eventCh)
+	tracer.DeleteProcessEventNotifyCh("subscriber")
+	tracer.AddProcessEventNotifyCh("subscriber", &eventCh)
+
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("tracing started %d times, want 2", got)
+	}
+	if got := stops.Load(); got != 1 {
+		t.Fatalf("tracing stopped %d times, want 1", got)
+	}
+	if !tracer.tracing {
+		t.Fatal("tracing was not active after the subscriber was re-added")
+	}
+}
+
+func TestProcessTracerClose_SynchronizesWithDelete(t *testing.T) {
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		var stops atomic.Int32
+		tracer := &ProcessTracer{
+			processEventChs: map[string]chan<- BpfProcessEvent{
+				"subscriber": make(chan BpfProcessEvent, 1),
+			},
+			tracing: true,
+			stopTracingFn: func() error {
+				stops.Add(1)
+				return nil
+			},
+			log: logr.Discard(),
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			tracer.DeleteProcessEventNotifyCh("subscriber")
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			tracer.Close()
+		}()
+		close(start)
+		wg.Wait()
+
+		tracer.Close()
+		if got := stops.Load(); got != 1 {
+			t.Fatalf("iteration %d: tracing stopped %d times, want 1", i, got)
+		}
+		if !tracer.closed {
+			t.Fatalf("iteration %d: tracer was not marked closed", i)
+		}
+		if !tracer.resourcesClosed {
+			t.Fatalf("iteration %d: tracer resources were not marked closed", i)
+		}
+		if len(tracer.snapshotProcessEventChs()) != 0 {
+			t.Fatalf("iteration %d: subscribers remain after close", i)
+		}
+	}
+}
+
+func TestProcessTracerClose_SynchronizesWithAdd(t *testing.T) {
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		var starts atomic.Int32
+		var stops atomic.Int32
+		tracer := &ProcessTracer{
+			processEventChs: make(map[string]chan<- BpfProcessEvent),
+			startTracingFn: func() error {
+				starts.Add(1)
+				return nil
+			},
+			stopTracingFn: func() error {
+				stops.Add(1)
+				return nil
+			},
+			log: logr.Discard(),
+		}
+		eventCh := make(chan BpfProcessEvent, 1)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			tracer.AddProcessEventNotifyCh("subscriber", &eventCh)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			tracer.Close()
+		}()
+		close(start)
+		wg.Wait()
+
+		startCount := starts.Load()
+		if startCount > 1 {
+			t.Fatalf("iteration %d: tracing started %d times, want at most 1", i, startCount)
+		}
+		if got := stops.Load(); got != startCount {
+			t.Fatalf("iteration %d: tracing started %d times but stopped %d times", i, startCount, got)
+		}
+		if !tracer.closed {
+			t.Fatalf("iteration %d: tracer was not marked closed", i)
+		}
+		if !tracer.resourcesClosed {
+			t.Fatalf("iteration %d: tracer resources were not marked closed", i)
+		}
+		if len(tracer.snapshotProcessEventChs()) != 0 {
+			t.Fatalf("iteration %d: subscribers remain after close", i)
+		}
+	}
+}
+
+func TestProcessTracerClose_PreventsRestart(t *testing.T) {
+	var starts atomic.Int32
+	tracer := &ProcessTracer{
+		processEventChs: make(map[string]chan<- BpfProcessEvent),
+		startTracingFn: func() error {
+			starts.Add(1)
+			return nil
+		},
+		log: logr.Discard(),
+	}
+
+	tracer.Close()
+	eventCh := make(chan BpfProcessEvent, 1)
+	tracer.AddProcessEventNotifyCh("subscriber", &eventCh)
+
+	if got := starts.Load(); got != 0 {
+		t.Fatalf("tracing started %d times after Close, want 0", got)
+	}
+	if len(tracer.snapshotProcessEventChs()) != 0 {
+		t.Fatal("subscriber was registered after Close")
+	}
+}
+
+func TestProcessTracerClose_RetriesFailedStop(t *testing.T) {
+	var stops atomic.Int32
+	var closes atomic.Int32
+	tracer := &ProcessTracer{
+		processEventChs: map[string]chan<- BpfProcessEvent{
+			"subscriber": make(chan BpfProcessEvent, 1),
+		},
+		tracing: true,
+		stopTracingFn: func() error {
+			if stops.Add(1) == 1 {
+				return errors.New("injected stop failure")
+			}
+			return nil
+		},
+		closeBpfObjsFn: func() error {
+			closes.Add(1)
+			return nil
+		},
+		log: logr.Discard(),
+	}
+
+	tracer.Close()
+	if !tracer.closed {
+		t.Fatal("tracer did not reject new subscribers after close began")
+	}
+	if tracer.resourcesClosed {
+		t.Fatal("tracer resources were marked closed after stop failed")
+	}
+	if !tracer.tracing {
+		t.Fatal("tracing was marked stopped after stop failed")
+	}
+	if got := closes.Load(); got != 0 {
+		t.Fatalf("BPF objects closed %d times before tracing stopped, want 0", got)
+	}
+
+	eventCh := make(chan BpfProcessEvent, 1)
+	tracer.AddProcessEventNotifyCh("new-subscriber", &eventCh)
+	if len(tracer.snapshotProcessEventChs()) != 0 {
+		t.Fatal("subscriber was registered while close was pending retry")
+	}
+
+	tracer.Close()
+	if got := stops.Load(); got != 2 {
+		t.Fatalf("stop attempted %d times, want 2", got)
+	}
+	if got := closes.Load(); got != 1 {
+		t.Fatalf("BPF objects closed %d times, want 1", got)
+	}
+	if tracer.tracing || !tracer.resourcesClosed {
+		t.Fatal("tracer did not complete cleanup after retry succeeded")
+	}
+
+	tracer.Close()
+	if got := stops.Load(); got != 2 {
+		t.Fatalf("successful cleanup was retried; stop calls = %d, want 2", got)
+	}
+	if got := closes.Load(); got != 1 {
+		t.Fatalf("successful cleanup was retried; BPF close calls = %d, want 1", got)
+	}
+}
+
+func TestProcessTracerClose_RetriesFailedBpfClose(t *testing.T) {
+	var closes atomic.Int32
+	tracer := &ProcessTracer{
+		processEventChs: make(map[string]chan<- BpfProcessEvent),
+		closeBpfObjsFn: func() error {
+			if closes.Add(1) == 1 {
+				return errors.New("injected BPF close failure")
+			}
+			return nil
+		},
+		log: logr.Discard(),
+	}
+
+	tracer.Close()
+	if !tracer.closed || tracer.resourcesClosed {
+		t.Fatal("failed BPF close did not leave cleanup retryable")
+	}
+
+	tracer.Close()
+	if !tracer.resourcesClosed {
+		t.Fatal("BPF cleanup retry did not complete")
+	}
+	if got := closes.Load(); got != 2 {
+		t.Fatalf("BPF close attempted %d times, want 2", got)
+	}
+
+	tracer.Close()
+	if got := closes.Load(); got != 2 {
+		t.Fatalf("successful BPF close was retried; calls = %d, want 2", got)
 	}
 }

--- a/pkg/processtracer/tracer.go
+++ b/pkg/processtracer/tracer.go
@@ -36,6 +36,11 @@ type ProcessTracer struct {
 	chsMu           sync.RWMutex
 	processEventChs map[string]chan<- BpfProcessEvent
 	tracing         bool
+	closed          bool
+	resourcesClosed bool
+	startTracingFn  func() error
+	stopTracingFn   func() error
+	closeBpfObjsFn  func() error
 	log             logr.Logger
 }
 
@@ -70,23 +75,44 @@ func (tracer *ProcessTracer) init() error {
 }
 
 func (tracer *ProcessTracer) Close() {
+	tracer.chsMu.Lock()
+	defer tracer.chsMu.Unlock()
+
+	if tracer.resourcesClosed {
+		return
+	}
+	tracer.closed = true
+	clear(tracer.processEventChs)
+
 	tracer.log.Info("unload the bpf resources of tracer")
-	tracer.stopTracing()
-	tracer.bpfObjs.Close()
+	if tracer.tracing || tracer.reader != nil || tracer.execLink != nil || tracer.forkLink != nil {
+		if err := tracer.disableTracing(); err != nil {
+			tracer.log.Error(err, "failed to disable tracing")
+			return
+		}
+		tracer.tracing = false
+	}
+	if err := tracer.closeBpfObjects(); err != nil {
+		tracer.log.Error(err, "failed to unload the bpf resources of tracer")
+		return
+	}
+	tracer.resourcesClosed = true
 }
 
 func (tracer *ProcessTracer) AddProcessEventNotifyCh(subscriber string, processEventCh *chan BpfProcessEvent) {
 	tracer.chsMu.Lock()
 	defer tracer.chsMu.Unlock()
 
-	if processEventCh != nil {
-		tracer.processEventChs[subscriber] = *processEventCh
+	if tracer.closed || processEventCh == nil {
+		return
 	}
+	tracer.processEventChs[subscriber] = *processEventCh
 
-	if len(tracer.processEventChs) == 1 {
-		err := tracer.startTracing()
+	if !tracer.tracing {
+		err := tracer.enableTracing()
 		if err != nil {
 			tracer.log.Error(err, "failed to enable tracing")
+			return
 		}
 		tracer.tracing = true
 	}
@@ -99,9 +125,33 @@ func (tracer *ProcessTracer) DeleteProcessEventNotifyCh(subscriber string) {
 	delete(tracer.processEventChs, subscriber)
 
 	if len(tracer.processEventChs) == 0 && tracer.tracing {
-		tracer.stopTracing()
+		if err := tracer.disableTracing(); err != nil {
+			tracer.log.Error(err, "failed to disable tracing")
+			return
+		}
 		tracer.tracing = false
 	}
+}
+
+func (tracer *ProcessTracer) enableTracing() error {
+	if tracer.startTracingFn != nil {
+		return tracer.startTracingFn()
+	}
+	return tracer.startTracing()
+}
+
+func (tracer *ProcessTracer) disableTracing() error {
+	if tracer.stopTracingFn != nil {
+		return tracer.stopTracingFn()
+	}
+	return tracer.stopTracing()
+}
+
+func (tracer *ProcessTracer) closeBpfObjects() error {
+	if tracer.closeBpfObjsFn != nil {
+		return tracer.closeBpfObjsFn()
+	}
+	return tracer.bpfObjs.Close()
 }
 
 func (tracer *ProcessTracer) snapshotProcessEventChs() []chan<- BpfProcessEvent {
@@ -116,17 +166,25 @@ func (tracer *ProcessTracer) snapshotProcessEventChs() []chan<- BpfProcessEvent 
 }
 
 func (tracer *ProcessTracer) startTracing() error {
+	if tracer.reader != nil || tracer.execLink != nil || tracer.forkLink != nil {
+		if err := tracer.stopTracing(); err != nil {
+			return fmt.Errorf("clean up stale tracing resources: %w", err)
+		}
+	}
+
 	err := tracer.attachBpfToTracepoint()
 	if err != nil {
-		return fmt.Errorf("attachBpfToTracepoint() failed: %v", err)
+		cleanupErr := tracer.unattachBpfToTracepoint()
+		return errors.Join(fmt.Errorf("attachBpfToTracepoint() failed: %w", err), cleanupErr)
 	}
 	err = tracer.createBpfEventsReader()
 	if err != nil {
-		return fmt.Errorf("createBpfEventsReader() failed: %v", err)
+		cleanupErr := tracer.unattachBpfToTracepoint()
+		return errors.Join(fmt.Errorf("createBpfEventsReader() failed: %w", err), cleanupErr)
 	}
 
 	// Handle bpf process events.
-	go tracer.handleBpfEvents()
+	go tracer.handleBpfEvents(tracer.reader)
 
 	tracer.log.Info("start tracing processes")
 
@@ -134,8 +192,13 @@ func (tracer *ProcessTracer) startTracing() error {
 }
 
 func (tracer *ProcessTracer) stopTracing() error {
-	tracer.closeBpfEventsReader()
-	tracer.unattachBpfToTracepoint()
+	err := errors.Join(
+		tracer.closeBpfEventsReader(),
+		tracer.unattachBpfToTracepoint(),
+	)
+	if err != nil {
+		return err
+	}
 
 	tracer.log.Info("stop tracing processes")
 	return nil
@@ -164,14 +227,24 @@ func (tracer *ProcessTracer) attachBpfToTracepoint() error {
 	return nil
 }
 
-func (tracer *ProcessTracer) unattachBpfToTracepoint() {
+func (tracer *ProcessTracer) unattachBpfToTracepoint() error {
+	var errs []error
 	if tracer.execLink != nil {
-		tracer.execLink.Close()
+		if err := tracer.execLink.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close exec tracepoint link: %w", err))
+		} else {
+			tracer.execLink = nil
+		}
 	}
 
 	if tracer.forkLink != nil {
-		tracer.forkLink.Close()
+		if err := tracer.forkLink.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close fork tracepoint link: %w", err))
+		} else {
+			tracer.forkLink = nil
+		}
 	}
+	return errors.Join(errs...)
 }
 
 // createBpfEventsReader open a perf event reader from kernel space on the BPF_MAP_TYPE_PERF_EVENT_ARRAY map.
@@ -184,16 +257,20 @@ func (tracer *ProcessTracer) createBpfEventsReader() error {
 	return nil
 }
 
-func (tracer *ProcessTracer) closeBpfEventsReader() {
+func (tracer *ProcessTracer) closeBpfEventsReader() error {
 	if tracer.reader != nil {
-		tracer.reader.Close()
+		if err := tracer.reader.Close(); err != nil {
+			return fmt.Errorf("close bpf events reader: %w", err)
+		}
+		tracer.reader = nil
 	}
+	return nil
 }
 
-func (tracer *ProcessTracer) handleBpfEvents() {
+func (tracer *ProcessTracer) handleBpfEvents(reader *perf.Reader) {
 	var event BpfProcessEvent
 	for {
-		record, err := tracer.reader.Read()
+		record, err := reader.Read()
 		if err != nil {
 			if errors.Is(err, perf.ErrClosed) {
 				tracer.log.V(2).Info("perf buffer reader is closed")


### PR DESCRIPTION
## Summary

- prevent duplicate registration of the same subscriber from starting process tracing repeatedly
- serialize ProcessTracer shutdown with subscriber registration and removal
- allow process tracing and BPF resource cleanup to be retried after partial failures
- bind each event handler goroutine to its own perf reader
- add regression coverage for subscriber re-registration, tracing restart, concurrent shutdown, and cleanup retries

## Root cause

The subscriber synchronization introduced in #371 protected the subscriber map, but tracing was still started whenever the map length was one. Re-registering the only subscriber replaced the existing map entry without changing the length, causing tracing to start again while it was already active.

`ProcessTracer.Close()` also bypassed the subscriber mutex and ignored resource cleanup errors. It could therefore race with subscriber updates, discard resource handles after failed cleanup, and prevent a later shutdown attempt from retrying the failed operation.

This change tracks the tracing and shutdown states explicitly, preserves resource handles until they are closed successfully, and only marks cleanup complete after all tracing and BPF resources have been released.

Follow-up to #371

## Verification

- `go test -race ./pkg/processtracer ./pkg/runtime`
- `go test -race -count=50 ./pkg/processtracer`
- `go test ./internal/behavior ./internal/agent`
- `go vet ./pkg/processtracer`
- `git diff --check`