### PR TITLE
fix(processtracer): mark tracing inactive after a failed stop so subscribers can restart collection

### DIFF
--- a/pkg/processtracer/subscriber_race_test.go
+++ b/pkg/processtracer/subscriber_race_test.go
@@ -149,6 +149,43 @@ func TestProcessEventNotifyCh_ReAddAfterDeleteRestartsTracing(t *testing.T) {
 	}
 }
 
+func TestProcessEventNotifyCh_ReAddAfterStopFailureRestartsTracing(t *testing.T) {
+	var starts atomic.Int32
+	var stops atomic.Int32
+	tracer := &ProcessTracer{
+		processEventChs: map[string]chan<- BpfProcessEvent{
+			"subscriber": make(chan BpfProcessEvent, 1),
+		},
+		tracing: true,
+		startTracingFn: func() error {
+			starts.Add(1)
+			return nil
+		},
+		stopTracingFn: func() error {
+			stops.Add(1)
+			return errors.New("injected stop failure")
+		},
+		log: logr.Discard(),
+	}
+
+	tracer.DeleteProcessEventNotifyCh("subscriber")
+	if tracer.tracing {
+		t.Fatal("tracing remained active after stop failed")
+	}
+	if got := stops.Load(); got != 1 {
+		t.Fatalf("tracing stopped %d times, want 1", got)
+	}
+
+	eventCh := make(chan BpfProcessEvent, 1)
+	tracer.AddProcessEventNotifyCh("subscriber", &eventCh)
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("tracing started %d times after re-add, want 1", got)
+	}
+	if !tracer.tracing {
+		t.Fatal("tracing was not active after the subscriber was re-added")
+	}
+}
+
 func TestProcessTracerClose_SynchronizesWithDelete(t *testing.T) {
 	const iterations = 100
 	for i := 0; i < iterations; i++ {

--- a/pkg/processtracer/tracer.go
+++ b/pkg/processtracer/tracer.go
@@ -125,11 +125,14 @@ func (tracer *ProcessTracer) DeleteProcessEventNotifyCh(subscriber string) {
 	delete(tracer.processEventChs, subscriber)
 
 	if len(tracer.processEventChs) == 0 && tracer.tracing {
-		if err := tracer.disableTracing(); err != nil {
-			tracer.log.Error(err, "failed to disable tracing")
-			return
-		}
+		err := tracer.disableTracing()
+		// Stopping can partially release the reader or links. Mark tracing
+		// inactive so the next subscriber retries startup and cleans up any
+		// stale resources first.
 		tracer.tracing = false
+		if err != nil {
+			tracer.log.Error(err, "failed to disable tracing")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix a state bug in `ProcessTracer.DeleteProcessEventNotifyCh`: when stopping tracing fails, the tracer now still marks `tracing` as inactive so a later subscriber can restart event collection instead of being permanently blocked by stale state.

## Problem

When the last process-event subscriber is removed, `DeleteProcessEventNotifyCh` calls `disableTracing()` to tear down the perf reader and detach the tracepoint links. Previously, if `disableTracing()` returned an error, the function logged it and returned early — without clearing `tracer.tracing`.

Stopping can partially release resources (e.g. the reader closed but link detach failed, or vice versa). Leaving `tracing` set to `true` after such a partial failure means the next `AddProcessEventNotifyCh` sees tracing as still active and never retries startup, so event collection is silently dead for all future subscribers even though the underlying resources are in a half-torn-down state.

## What Changed

- In `DeleteProcessEventNotifyCh` (`pkg/processtracer/tracer.go`), `tracer.tracing` is now set to `false` unconditionally after every stop attempt — both on success and on failure. The error is still logged.
- With the state reset, the next subscriber that is added goes through the normal startup path, which cleans up any stale resources left over from the partial stop before re-attaching.

## Tests

- Added `TestProcessEventNotifyCh_ReAddAfterStopFailureRestartsTracing` in `pkg/processtracer/subscriber_race_test.go`:
  - Injects a failing `stopTracingFn` and verifies `tracing` is `false` after `DeleteProcessEventNotifyCh` (and that stop was attempted exactly once).
  - Re-adds a subscriber and verifies `startTracingFn` is invoked exactly once and `tracing` becomes active again.

## Files Changed

| Area | Files |
|---|---|
| Stop-failure state handling | `pkg/processtracer/tracer.go` |
| Regression test | `pkg/processtracer/subscriber_race_test.go` |
