### PR TITLE
fix(networkproxy): inject VARMOR_NAMESPACE on the controller reconcile path

### DIFF
--- a/internal/policy/audit_update_test.go
+++ b/internal/policy/audit_update_test.go
@@ -79,6 +79,7 @@ func Test_applyAuditToSidecar(t *testing.T) {
 	assert.Equal(t, envByName["POLICY_KIND"].Value, "VarmorPolicy")
 	assert.Equal(t, envByName["POLICY_NAME"].Value, "test")
 	assert.Equal(t, envByName["POLICY_NAMESPACE"].Value, "testns")
+	assert.Equal(t, envByName["VARMOR_NAMESPACE"].Value, varmorconfig.Namespace)
 	assert.Equal(t, envByName["VARMOR_ENVOY_UID"].Value, "1337")
 
 	// App container must be untouched.
@@ -178,6 +179,7 @@ func Test_cleanupAuditFromSidecar(t *testing.T) {
 				{Name: "POD_NAME"},
 				{Name: "POD_NAMESPACE"},
 				{Name: "POD_UID"},
+				{Name: "VARMOR_NAMESPACE", Value: "varmor"},
 			},
 		},
 	}

--- a/internal/policy/update.go
+++ b/internal/policy/update.go
@@ -302,6 +302,7 @@ var auditSinkEnvNames = map[string]bool{
 	"POLICY_KIND":          true,
 	"POLICY_NAME":          true,
 	"POLICY_NAMESPACE":     true,
+	"VARMOR_NAMESPACE":     true,
 	"VARMOR_ENVOY_UID":     true,
 	"AUDIT_EVENT_METADATA": true,
 }
@@ -314,6 +315,7 @@ var auditSinkEnvNames = map[string]bool{
 //   - NODE_NAME (Downward API spec.nodeName): node attribution.
 //   - PROFILE_NAME / POLICY_KIND / POLICY_NAME / POLICY_NAMESPACE: the policy
 //     identity the sink seeds so violation records carry the owning policy.
+//   - VARMOR_NAMESPACE: the namespace where vArmor itself is installed.
 //   - VARMOR_ENVOY_UID: the uid the entrypoint drops to before exec-ing Envoy,
 //     kept in sync with the iptables uid-owner RETURN exemption (proxyUID).
 //   - AUDIT_EVENT_METADATA: the cluster metadata literal the manager carries,
@@ -326,6 +328,7 @@ func auditSinkEnvVars(profileName string, id AuditPolicyIdentity, proxyUID int64
 		{Name: "POLICY_KIND", Value: id.Kind},
 		{Name: "POLICY_NAME", Value: id.Name},
 		{Name: "POLICY_NAMESPACE", Value: id.Namespace},
+		{Name: "VARMOR_NAMESPACE", Value: varmorconfig.Namespace},
 		{Name: "VARMOR_ENVOY_UID", Value: strconv.FormatInt(proxyUID, 10)},
 	}
 	if md := os.Getenv("AUDIT_EVENT_METADATA"); md != "" {
@@ -334,9 +337,10 @@ func auditSinkEnvVars(profileName string, id AuditPolicyIdentity, proxyUID int64
 	return envs
 }
 
-// cleanupAuditFromSidecar removes the ALS socket volumeMount and the three
-// Downward API env vars from the Envoy sidecar container if present, keeping
-// reconciliation idempotent when the NetworkProxy enforcer is removed.
+// cleanupAuditFromSidecar removes the ALS socket volumeMount, the Downward API
+// env vars, and all in-sidecar audit sink env vars from the Envoy sidecar if
+// present, keeping reconciliation idempotent when the NetworkProxy enforcer is
+// removed.
 func cleanupAuditFromSidecar(containers []coreV1.Container) {
 	for i := range containers {
 		if containers[i].Name != proxyContainer.Name {


### PR DESCRIPTION
## Summary

Inject the `VARMOR_NAMESPACE` environment variable into the NetworkProxy sidecar on the controller reconcile path (`internal/policy/update.go`), matching what the webhook mutation path already does. Without it, workloads that receive the sidecar via the controller's update path (rather than through admission) run the in-sidecar audit sink without the vArmor installation namespace, so the sink falls back to the workload's own namespace when attributing violation records.

## Problem

vArmor's NetworkProxy enforcer has two sidecar injection surfaces:

- **Webhook mutation path** (`internal/webhooks/mutation.go`) — injects new pods at admission time. This path already sets `VARMOR_NAMESPACE` to the manager's own namespace.
- **Controller reconcile path** (`internal/policy/update.go`, `auditSinkEnvVars()`) — updates *existing* workloads when a NetworkProxy policy is applied. This path injected the policy identity and Envoy UID env vars, but omitted `VARMOR_NAMESPACE`.

The in-sidecar audit sink resolves the vArmor namespace in `internal/config/config.go`: it prefers `VARMOR_NAMESPACE` and falls back to `POD_NAMESPACE` when unset. For pods reconciled by the controller, `POD_NAMESPACE` is the *workload's* namespace — not the vArmor install namespace — so violation records produced by the in-sidecar sink carried the wrong namespace attribution.

## What Changed

- Added `VARMOR_NAMESPACE` (set to `varmorconfig.Namespace`) to the env vars injected by `auditSinkEnvVars()` in `internal/policy/update.go`.
- Added `VARMOR_NAMESPACE` to the `auditSinkEnvNames` cleanup set so `cleanupAuditFromSidecar()` removes it again when the NetworkProxy enforcer is removed, keeping reconciliation idempotent and symmetric with injection.
- Updated the `auditSinkEnvVars` doc comment to list the new variable.

## Tests

- Extended `Test_applyAuditToSidecar` to assert that `VARMOR_NAMESPACE` equals `varmorconfig.Namespace` after injection.
- Extended `Test_cleanupAuditFromSidecar` to seed a sidecar carrying `VARMOR_NAMESPACE` and verify it is removed during audit cleanup.

## Files Changed

| Area | Files |
|---|---|
| Injection & cleanup logic | `internal/policy/update.go` |
| Regression tests | `internal/policy/audit_update_test.go` |
